### PR TITLE
Handle Motorola Phonebooks that don't start at 1.

### DIFF
--- a/libgammu/phone/at/motorola.c
+++ b/libgammu/phone/at/motorola.c
@@ -280,6 +280,7 @@ GSM_Error MOTOROLA_ReplyGetMemory(GSM_Protocol_Message *msg, GSM_StateMachine *s
 					&number_type,
 					Memory->Entries[1].Text, sizeof(Memory->Entries[1].Text),
 					&entry_type);
+		Memory->Location = Memory->Location + 1 - Priv->MotorolaFirstMemoryEntry;
 		switch (entry_type) {
 			case 0:
 				Memory->Entries[0].EntryType = PBK_Number_General;


### PR DESCRIPTION
MOTOROLA_ReplyGetMemory() saved the actual location read in Memory->Location, rather than the offset from the beginning of the phonebook, which is how it is used elsewhere.  For reading single entries, this was not a problem, but for the getallmemory function, it skips great swathes of the phone book.
