### PR TITLE
Update gammu.c

### DIFF
--- a/gammu/gammu.c
+++ b/gammu/gammu.c
@@ -358,10 +358,10 @@ static void RunBatch(int argc, char *argv[])
 	/**
 	 * @todo Allocate memory dynamically.
 	 */
-	char ln[2000];
+	char ln[2000], token;
 	size_t i, len;
 	ssize_t pos;
-	int j, c = 0, argsc;
+	int j, c = 0, argsc, n;
 	char *argsv[20];
 	gboolean origbatch;
 	char *name;


### PR DESCRIPTION
Added support for parameters that contain space (or spaces) in batch mode.

For example let's try to send mail in batch mode:

> gammu batch
> sendsms TEXT +48333444555 -text 'Batch mode. Sending sms nr 1'

By default Gammu doesn't work. We'll get following error message: Unknown parameter "mode".
Gammu doesn't care about params written with using " or ' char by default.

My patch fix it.
