### PR TITLE
Fixing _FORTIFY_SOURCE error when compile on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,6 +467,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_MINGW OR
     #
     # Warnings related flags
     #
+    MACRO_TUNE_COMPILER("-O2")
     MACRO_TUNE_COMPILER("-Wall")
     MACRO_TUNE_COMPILER("-Werror-implicit-function-declaration")
     MACRO_TUNE_COMPILER("-Wno-deprecated-declarations")

--- a/smsd/services/pgsql.c
+++ b/smsd/services/pgsql.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2009 - 2011 Michal Cihar <michal@cihar.com> */
 
 #define _XOPEN_SOURCE
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <time.h>
 
 #include <gammu.h>

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -10,7 +10,7 @@
  */
 
 #define _XOPEN_SOURCE
-#define _BSD_SOURCE
+#define _DEFAULT_SOURCE
 #include <time.h>
 #include <gammu.h>
 #include "../../helper/strptime.h"


### PR DESCRIPTION
Fixing _FORTIFY_SOURCE with adding MACRO_TUNE_COMPILER(-O2) on CMAKELists.txt 
and change _BSD_SOURCE to _DEFAULT_SOURCE on smsd/services/sql.c and smsd/services/pgsql.c
