### PR TITLE
Install bash-completion to where bash-completion.pc says

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -83,9 +83,13 @@ if (INSTALL_PHP_EXAMPLES)
 endif (INSTALL_PHP_EXAMPLES)
 
 if (INSTALL_BASH_COMPLETION)
+    macro_optional_find_package (bash-completion QUIET)
+    if (NOT BASH_COMPLETION_FOUND)
+        set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
+    endif (NOT BASH_COMPLETION_FOUND)
     install (
         FILES bash-completion/gammu
-        DESTINATION "/etc/bash_completion.d"
+        DESTINATION ${BASH_COMPLETION_COMPLETIONSDIR}
         COMPONENT "bash"
         )
 endif (INSTALL_BASH_COMPLETION)


### PR DESCRIPTION
bash-completion CMake support will be shipped in bash-completion >= 2.2.

Signed-off-by: Ville Skyttä <ville.skytta@iki.fi>