### PR TITLE
contrib: cache BASH_COMPLETION_COMPLETIONSDIR

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -85,7 +85,7 @@ endif (INSTALL_PHP_EXAMPLES)
 if (INSTALL_BASH_COMPLETION)
     macro_optional_find_package (BashCompletion)
     if (NOT BASH_COMPLETION_FOUND)
-        set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d")
+      set (BASH_COMPLETION_COMPLETIONSDIR "/etc/bash_completion.d" CACHE PATH "Location of bash_completion.d")
     endif (NOT BASH_COMPLETION_FOUND)
     install (
         FILES bash-completion/gammu


### PR DESCRIPTION
To allow the path to bash_completion.d to be set when running `cmake`; I needed this change for a non-sudo install on OSX.