### PR TITLE
Fix always-evaluates-to-true bug in Bitmap handling

### DIFF
--- a/gammu/misc.c
+++ b/gammu/misc.c
@@ -1138,7 +1138,7 @@ void GetBitmap(int argc, char *argv[])
 		GSM_PrintBitmap(stdout,&MultiBitmap.Bitmap[0]);
 		printf(LISTFORMAT "\"%s\"\n", _("Text"),DecodeUnicodeConsole(MultiBitmap.Bitmap[0].Text));
 		printf(LISTFORMAT "\"%s\"\n", _("Sender"),DecodeUnicodeConsole(MultiBitmap.Bitmap[0].Sender));
-		if (MultiBitmap.Bitmap[0].Name)
+		if (MultiBitmap.Bitmap[0].Name[0])
 			printf(LISTFORMAT "\"%s\"\n", _("Name"),DecodeUnicodeConsole(MultiBitmap.Bitmap[0].Name));
 		if (argc>4) error=GSM_SaveBitmapFile(argv[4],&MultiBitmap);
 		break;


### PR DESCRIPTION
Causes a build error with clang on OSX using homebrew's `-Werror` settings:

```
[ 95%] Building C object gammu/CMakeFiles/gammu.dir/misc.c.o
/Users/rcoup/code/gammu/gammu/misc.c:1141:29: warning: address of array 'MultiBitmap.Bitmap[0].Name' will always evaluate to 'true' [-Wpointer-bool-conversion]
                if (MultiBitmap.Bitmap[0].Name)
                ~~  ~~~~~~~~~~~~~~~~~~~~~~^~~~
1 warning generated.
```