### PR TITLE
Fix AT+CGREG parsing for some at-modem

### DIFF
--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -2909,7 +2909,7 @@ GSM_Error ATGEN_ReplyGetPacketNetworkLAC_CID(GSM_Protocol_Message *msg, GSM_Stat
 	if (error == ERR_UNKNOWNRESPONSE) {
 	        error = ATGEN_ParseReply(s,
 			GetLineString(msg->Buffer, &Priv->Lines, 2),
-			"+CGREG: @i, @i, @r, @r",
+			"+CGREG: @i, @i, @r, @r, @i",
 			&i, /* Mode, ignored for now */
 			&state,
 			NetworkInfo->PacketLAC, sizeof(NetworkInfo->PacketLAC),

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -2905,6 +2905,19 @@ GSM_Error ATGEN_ReplyGetPacketNetworkLAC_CID(GSM_Protocol_Message *msg, GSM_Stat
 			&rac, sizeof(rac) /* Routing Area Code, ignored for now */
 			);
 
+	/* Reply without RAC */
+	if (error == ERR_UNKNOWNRESPONSE) {
+	        error = ATGEN_ParseReply(s,
+			GetLineString(msg->Buffer, &Priv->Lines, 2),
+			"+CGREG: @i, @i, @r, @r",
+			&i, /* Mode, ignored for now */
+			&state,
+			NetworkInfo->PacketLAC, sizeof(NetworkInfo->PacketLAC),
+			NetworkInfo->PacketCID, sizeof(NetworkInfo->PacketCID),
+			&act /* Access Technology, ignored for now */
+			);
+	}
+
 	/* Reply without ACT/RAC */
 	if (error == ERR_UNKNOWNRESPONSE) {
 	        error = ATGEN_ParseReply(s,


### PR DESCRIPTION
Some Modem like Quectel UC15 have 5  response value like +CGREG:  <stat>[,[<lac>],[<ci>],
[<AcT>],[<rac>]] and without this change GSM_GetNetworkInfo has UNKNOWN response error.