### PR TITLE
Add build with static runtime library under MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ include (MacroOptionalFindPackage)
 include (MacroAddDLL)
 include (MacroGammuOption)
 include (MacroTuneCompiler)
+include (MSVCRuntime)
 
 # WE use pkgconfig later
 find_package (PkgConfig)
@@ -429,6 +430,9 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
     set(MATH_LIBS "")
+    
+   # Call cmake with "-DMSVC_RUNTIME=static" to link with static runtime libraries
+   configure_msvc_runtime()
 else(MSVC)
     set(MATH_LIBS "-lm")
 endif(MSVC)

--- a/cmake/MSVCRuntime.cmake
+++ b/cmake/MSVCRuntime.cmake
@@ -1,0 +1,41 @@
+macro(configure_msvc_runtime)
+	if(MSVC)
+		# Default to statically-linked runtime.
+		if("${MSVC_RUNTIME}" STREQUAL "")
+			set(MSVC_RUNTIME "dynamic")
+		endif()
+
+		# Set compiler options.
+		set(variables
+			CMAKE_C_FLAGS
+			CMAKE_C_FLAGS_DEBUG
+			CMAKE_C_FLAGS_MINSIZEREL
+			CMAKE_C_FLAGS_RELEASE
+			CMAKE_C_FLAGS_RELWITHDEBINFO
+			CMAKE_CXX_FLAGS
+			CMAKE_CXX_FLAGS_DEBUG
+			CMAKE_CXX_FLAGS_MINSIZEREL
+			CMAKE_CXX_FLAGS_RELEASE
+			CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+
+		if(${MSVC_RUNTIME} STREQUAL "static")
+			message(STATUS "MSVC: using statically-linked runtime (/MT and /MTd).")
+			foreach(variable ${variables})
+				if(${variable} MATCHES "/MD")
+					string(REGEX REPLACE "/MD" "/MT" ${variable} "${${variable}}")
+				endif()
+			endforeach()
+		else()
+			message(STATUS "MSVC: using dynamically-linked runtime (/MD and /MDd).")
+			foreach(variable ${variables})
+				if(${variable} MATCHES "/MT")
+					string(REGEX REPLACE "/MT" "/MD" ${variable} "${${variable}}")
+				endif()
+			endforeach()
+		endif()
+
+		foreach(variable ${variables})
+			set(${variable} "${${variable}}" CACHE STRING "MSVC_${variable}" FORCE)
+		endforeach()
+	endif()
+endmacro(configure_msvc_runtime)


### PR DESCRIPTION
Add the possibility to build Gammu with static runtime library under MSVC.

cmake must be called with "-DMSVC_RUNTIME=static"