### PR TITLE
RunOnReceive: Environment variable PHONE_ID

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,7 +23,7 @@ ChangeLog
 
 [-] * Improve support for Huawei K3765.
 [-] * Fixed decoding of unicode surrogates at message boundary.
-[+] * Environment variable PHONE_ID for external program
+[+] * Environment variable PHONE_ID for external program.
 
 20170105 - 1.38.1
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ ChangeLog
 
 [-] * Improve support for Huawei K3765.
 [-] * Fixed decoding of unicode surrogates at message boundary.
+[+] * Environment variable PHONE_ID for external program
 
 20170105 - 1.38.1
 

--- a/docs/manual/smsd/run.rst
+++ b/docs/manual/smsd/run.rst
@@ -48,6 +48,13 @@ Global variables
 
     Number of decoded message parts.
 
+.. envvar:: PHONE_ID
+
+    .. versionadded:: 1.38.2
+
+    Value of :config:option:`PhoneID`. Useful when running multiple instances
+    (see :ref:`smsd-multi`).
+
 Per message variables
 +++++++++++++++++++++
 

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1036,6 +1036,11 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
 	/* Raw message data */
 	sprintf(buffer, "%d", sms->Number);
 	setenv("SMS_MESSAGES", buffer, 1);
+
+	if (Config->PhoneID) {
+		setenv("PHONE_ID", Config->PhoneID, 1);
+	}
+
 	for (i = 0; i < sms->Number; i++) {
 		sprintf(buffer, "%d", sms->SMS[i].Class);
 		sprintf(name, "SMS_%d_CLASS", i + 1);


### PR DESCRIPTION
The configuration field PhoneID is useful to run several SMS daemons. It is stored as SenderID in the database, but it could be also useful to have this information in an external program (RunOnXXX), at least for me.

So, I have added the environment variable "PHONE_ID".