### PR TITLE
Added gammu-safe example

### DIFF
--- a/docs/manual/smsd/smsd.rst
+++ b/docs/manual/smsd/smsd.rst
@@ -232,6 +232,30 @@ workaround this limitation by suspending SMSD temporarily using `SIGUSR1` and
         kill -SIGUSR2 $SMSD_PID
     fi
 
+Or even create a `gammu-safe` script:
+
+.. code-block:: sh
+    #!/bin/bash
+    SMSD_PID=`pidof gammu-smsd`
+    if [ -z "$SMSD_PID" ] ; then
+      gammu $@
+    else
+      tty=$(lsof |grep -E "gammu-sms\s+$SMSD_PID\s+.*/dev/tty*"|awk {'print $NF'})
+      kill -SIGUSR1 $SMSD_PID
+      while test "$(fuser $ttyfuser $tty 2> /dev/null|xargs)" = $SMSD_PID
+      do
+        sleep 1
+      done
+      sleep 1
+      gammu $@
+      kill -SIGUSR2 $SMSD_PID
+      while test "$(fuser $ttyfuser $tty 2> /dev/null|xargs)" != $SMSD_PID
+      do
+        sleep 1
+      done
+      sleep 1
+    fi
+
 
 Known Limitations
 -----------------


### PR DESCRIPTION
Added `gammu-safe` example as initial script missed arguments, ability to run with smsd service down and didnt work on raspberry pi – smsd service doesn't react immediately there.