### PR TITLE
log filename is output to `stderr' instead of `stdout' when file logging is configured

### DIFF
--- a/smsd/core.c
+++ b/smsd/core.c
@@ -644,7 +644,7 @@ GSM_Error SMSD_ConfigureLogging(GSM_SMSDConfig *Config, gboolean uselog)
 			fprintf(stderr, "Can't open log file \"%s\"\n", Config->logfilename);
 			return ERR_CANTOPENFILE;
 		}
-		fprintf(stderr, "Log filename is \"%s\"\n",Config->logfilename);
+		fprintf(stdout, "Log filename is \"%s\"\n",Config->logfilename);
 	}
 	return ERR_NONE;
 }


### PR DESCRIPTION
A text string "Log filename is [NAME_OF_LOGFILE]" is sent to `stderr` when `gammu-smsd` is started and configured to use a log file as logging facility. Since this is an info message, output should be sent to `stdout` instead.