### PR TITLE
Add message TPMR to RunOnReceive directive

### DIFF
--- a/docs/man/gammu-smsd-run.7
+++ b/docs/man/gammu-smsd-run.7
@@ -103,6 +103,11 @@ Sender number.
 .B SMS_1_TEXT
 Message text. Text is not available for 8\-bit binary messages.
 .UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_REFERENCE
+Message Reference. If delivery status received, this variable contains TPMR of original message
+.UNINDENT
 .SS Per part variables
 .sp
 The variables further described as \fBDECODED_1_...\fP are generated for each message

--- a/docs/manual/smsd/run.rst
+++ b/docs/manual/smsd/run.rst
@@ -73,6 +73,10 @@ message, where 1 is replaced by current number of message.
 
     Message text. Text is not available for 8-bit binary messages.
 
+.. envvar:: SMS_1_REFERENCE
+
+    Message Reference. If delivery status received, this variable contains TPMR of original message
+
 Per part variables
 ++++++++++++++++++
 

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -60,7 +60,7 @@
 #endif
 
 #include "../libgammu/misc/string.h"
-
+#include "../include/gammu-message.h"
 #ifndef PATH_MAX
 #ifdef MAX_PATH
 #define PATH_MAX (MAX_PATH)
@@ -1060,6 +1060,9 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
 	for (i = 0; i < sms->Number; i++) {
 		sprintf(buffer, "%d", sms->SMS[i].Class);
 		sprintf(name, "SMS_%d_CLASS", i + 1);
+		setenv(name, buffer, 1);
+		sprintf(buffer, "%d", sms->SMS[i].MessageReference);
+		sprintf(name, "SMS_%d_REFERENCE", i + 1);
 		setenv(name, buffer, 1);
 		sprintf(name, "SMS_%d_NUMBER", i + 1);
 		setenv(name, DecodeUnicodeConsole(sms->SMS[i].Number), 1);


### PR DESCRIPTION
Adds TPMR variable to RunOnReceive event. 

With this variable, it's able to determine if a message is delivery report, and if it is, it's containing TPMR of base message.

Tested on Ubuntu 16.04.2