### PR TITLE
Triggering a shell script on a canceled phone call.

### DIFF
--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1943,7 +1943,7 @@ void SMSD_IncomingCallCallback(GSM_StateMachine *s, GSM_Call *call, void *user_d
 			}
 
 			if (Config->RunOnIncomingCall != NULL) {
-				const size_t BUFS=1024;
+				const unsigned int BUFS=1024;
 				char buf[BUFS];
 				int ret=0;
 				snprintf(buf, BUFS,"%s '%s'",

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -862,6 +862,7 @@ GSM_Error SMSD_ReadConfig(const char *filename, GSM_SMSDConfig *Config, gboolean
 	Config->RunOnReceive = INI_GetValue(Config->smsdcfgfile, "smsd", "runonreceive", FALSE);
 	Config->RunOnFailure = INI_GetValue(Config->smsdcfgfile, "smsd", "runonfailure", FALSE);
 	Config->RunOnSent = INI_GetValue(Config->smsdcfgfile, "smsd", "runonsent", FALSE);
+	Config->RunOnIncomingCall = INI_GetValue(Config->smsdcfgfile, "smsd", "runonincomingcall", FALSE);
 
 	str = INI_GetValue(Config->smsdcfgfile, "smsd", "smsc", FALSE);
 	if (str) {
@@ -1939,6 +1940,19 @@ void SMSD_IncomingCallCallback(GSM_StateMachine *s, GSM_Call *call, void *user_d
 				GSM_CancelCall(s, call->CallID, TRUE);
 			} else {
 				GSM_CancelCall(s, 0, TRUE);
+			}
+
+			if (Config->RunOnIncomingCall != NULL) {
+				const size_t BUFS=1024;
+				char buf[BUFS];
+				int ret=0;
+				snprintf(buf, BUFS,"%s '%s'",
+					 Config->RunOnIncomingCall,
+					 DecodeUnicodeString(call->PhoneNumber));
+				ret = system(buf);
+				if (ret<0) {
+					SMSD_Log(DEBUG_ERROR, Config, "Incoming call -  could not run script: %s\n", strerror(errno) );
+				}
 			}
 		}
 		break;

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1943,7 +1943,7 @@ void SMSD_IncomingCallCallback(GSM_StateMachine *s, GSM_Call *call, void *user_d
 			}
 
 			if (Config->RunOnIncomingCall != NULL) {
-				const unsigned int BUFS=1024;
+#define BUFS 1024
 				char buf[BUFS];
 				int ret=0;
 				snprintf(buf, BUFS,"%s '%s'",

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -87,6 +87,7 @@ struct _GSM_SMSDConfig {
 	const char   *RunOnReceive;
 	const char   *RunOnFailure; /* run this command on phone communication failure */
 	const char   *RunOnSent; /* run this command when an SMS has been sent successfully */
+	const char   *RunOnIncomingCall; /* run this command when a phone call has been canceled */
 	gboolean checksecurity;
 	gboolean hangupcalls;
 	gboolean checkbattery;


### PR DESCRIPTION
Just a small extension: People eventually call in on my SMS number. I try to be polite and send them a short SMS with further instructions via a shell script.

You can activate this via a RunOnIncomingCall config option in the smsdrc file.

If you think its useful, merge it.
Simon