### PR TITLE
Reset crashed device if needed

### DIFF
--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -4725,8 +4725,11 @@ GSM_Error ATGEN_Reset(GSM_StateMachine *s, gboolean hard)
 	}
 	smprintf(s, "Resetting device\n");
 
-	/* Siemens 35 */
-	error = ATGEN_WaitForAutoLen(s, "AT+CFUN=1,1\r", 0x00, 20, ID_Reset);
+	/* Regular phones */
+	error = ATGEN_WaitForAutoLen(s, "AT+CFUN=0\r", 0x00, 20, ID_Reset);
+	if (error == ERR_NONE) {
+		error = ATGEN_WaitForAutoLen(s, "AT+CFUN=1,1\r", 0x00, 20, ID_Reset);
+	}
 
 	if (error != ERR_NONE) {
 		/* Siemens M20 */

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -2196,6 +2196,11 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 			if (error == ERR_EMPTY) {
 				lastnothingsent = lastloop;
 			}
+			if (error == ERR_UNKNOWN) {
+				/* Huawei devices may return UNKNOWN errors. A soft reset may help to recover */
+				SMSD_LogError(DEBUG_INFO, Config, "Resetting the device because of error", error);
+				force_reset = TRUE;
+			}
 			/* We don't care about other errors here, they are handled in SMSD_SendSMS */
 		}
 		if (Config->shutdown) {


### PR DESCRIPTION
**I have only tested this with my own device.**
My Huawei E303 dongle constantly bugs/crashes after a month or so of use. The only solution is to reset it (see the commit message).
This commit successfully resets my dongle when this bug is encountered. However, I have no way to test it on other devices. Could you please double check I have not broken the `ATGEN_Reset` function for non-E303 devices?

Thanks