### PR TITLE
[SMSD] process status reports from SR memory via +CDSI messages

### DIFF
--- a/include/gammu-error.h
+++ b/include/gammu-error.h
@@ -351,6 +351,14 @@ typedef enum {
 	 * Error in executing SQL query.
 	 */
 	ERR_SQL,
+	/**
+	 * The operation cannot be performed.
+	 */
+	ERR_INVALID_OPERATION,
+	/**
+	 * The type of memory is not available or has been disabled.
+	 */
+	ERR_MEMORY_NOT_AVAILABLE,
 
 	/**
 	 * Just marker of highest error code, should not be used.

--- a/include/gammu-info.h
+++ b/include/gammu-info.h
@@ -726,6 +726,15 @@ typedef enum {
 	 * Prefer GSM charset for USSD (default is unicode).
 	 */
 	F_USSD_GSM_CHARSET,
+	/**
+	 * Phone supports SR storage even if it does not report
+	 * so.
+	 */
+	F_SMS_SR,
+	/**
+	 * Phone does not have a SR memory even if it reports so.
+	 */
+	F_SMS_NO_SR,
 
 	/**
 	 * Just marker of highest feature code, should not be used.

--- a/include/gammu-memory.h
+++ b/include/gammu-memory.h
@@ -76,6 +76,10 @@ typedef enum {
 	 * Quick dialing choices.
 	 */
 	MEM_QD,
+	/**
+	 * Status report memory
+	 */
+	MEM_SR,
 
 	/**
 	 * Invalid memory type.
@@ -103,7 +107,8 @@ typedef enum {
 	((x) == MEM_FD ? "FD" :	\
 	((x) == MEM_VM ? "VM" :	\
 	((x) == MEM_QD ? "QD" :	\
-	((x) == MEM_SL ? "SL" : "XX")))))))))))
+	((x) == MEM_SL ? "SL" : \
+	((x) == MEM_SR ? "SR" :	"XX"))))))))))))
 
 /**
  * Converts memory type from string.

--- a/libgammu/gsmcomon.c
+++ b/libgammu/gsmcomon.c
@@ -160,6 +160,8 @@ static PrintErrorEntry PrintErrorEntries[] = {
 	{ERR_DB_CONNECT, "DB_CONNECT", N_("Failed to connect to database.")},
 	{ERR_DB_TIMEOUT, "DB_TIMEOUT", N_("Database connection timeout.")},
 	{ERR_SQL, "SQL", N_("Error in executing SQL query.")},
+	{ERR_MEMORY_NOT_AVAILABLE, "MEMORY_NOT_AVAILABLE", N_("The type of memory is not available or has been disabled.")},
+	{ERR_INVALID_OPERATION, "INVALID_OPERATION", N_("The operation cannot be performed.")},
 
 	{0,	"",				""}
 };

--- a/libgammu/gsmphones.c
+++ b/libgammu/gsmphones.c
@@ -130,6 +130,8 @@ GSM_FeatureName AllFeatureNames[] = {
 	{"HUAWEI_INIT", F_HUAWEI_INIT},
 	{"ZTE_INIT", F_ZTE_INIT},
 	{"USSD_GSM_CHARSET", F_USSD_GSM_CHARSET},
+	{"SMS_SR", F_SMS_SR},
+	{"SMS_NO_SR", F_SMS_NO_SR},
 	{"", 0},
 };
 

--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -23,6 +23,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <stdarg.h>
+#include <assert.h>
 
 #include "../../gsmcomon.h"
 #include "../../gsmphones.h"
@@ -76,10 +77,11 @@ GSM_Error ATGEN_ReplyGetSMSMemories(GSM_Protocol_Message *msg, GSM_StateMachine 
 		 * phone supports writing to memory. This is done by searching
 		 * for "), (", which will appear between lists.
 		 *
-		 * @todo: Add support for BM (broadcast messages) and SR (status reports).
+		 * @todo: Add support for BM (broadcast messages).
 		 */
 		Priv->PhoneSaveSMS = AT_NOTAVAILABLE;
 		Priv->SIMSaveSMS = AT_NOTAVAILABLE;
+		Priv->SRSaveSMS = AT_NOTAVAILABLE;
 
 		Line = GetLineString(msg->Buffer, &Priv->Lines, 2);
 		/* Skip empty line in response */
@@ -122,11 +124,22 @@ GSM_Error ATGEN_ReplyGetSMSMemories(GSM_Protocol_Message *msg, GSM_StateMachine 
 			if (pos_tmp != NULL && pos_tmp < pos_end) {
 				Priv->PhoneSaveSMS = AT_AVAILABLE;
 			}
+
+			pos_tmp = strstr(pos_start, "\"SR\"");
+
+			if (pos_tmp != NULL && pos_tmp < pos_end) {
+				Priv->SRSaveSMS = AT_AVAILABLE;
+			}
 		}
 		if (strstr(msg->Buffer, "\"SM\"") != NULL) {
 			Priv->SIMSMSMemory = AT_AVAILABLE;
 		} else {
 			Priv->SIMSMSMemory = AT_NOTAVAILABLE;
+		}
+		if (strstr(msg->Buffer, "\"SR\"") != NULL) {
+			Priv->SRSMSMemory = AT_AVAILABLE;
+		} else {
+			Priv->SRSMSMemory = AT_NOTAVAILABLE;
 		}
 		if (strstr(msg->Buffer, "\"ME\"") != NULL) {
 			Priv->PhoneSMSMemory = AT_AVAILABLE;
@@ -142,11 +155,13 @@ GSM_Error ATGEN_ReplyGetSMSMemories(GSM_Protocol_Message *msg, GSM_StateMachine 
 
 		}
 completed:
-		smprintf(s, "Available SMS memories received: read: ME : %s, SM : %s, save: ME : %s, SM = %s, Motorola = %s\n",
+		smprintf(s, "Available SMS memories received: read: ME : %s, SM : %s, SR : %s save: ME : %s, SM : %s, SR : %s, Motorola = %s\n",
 				Priv->PhoneSMSMemory == AT_AVAILABLE ? "ok" : "N/A",
 				Priv->SIMSMSMemory == AT_AVAILABLE ? "ok" : "N/A",
+	 		  Priv->SRSMSMemory == AT_AVAILABLE ? "ok" : "N/A",
 				Priv->PhoneSaveSMS == AT_AVAILABLE ? "ok" : "N/A",
 				Priv->SIMSaveSMS == AT_AVAILABLE ? "ok" : "N/A",
+				Priv->SRSaveSMS == AT_AVAILABLE ? "ok" : "N/A",
 				Priv->MotorolaSMS ? "yes" : "no"
 				);
 
@@ -184,6 +199,14 @@ GSM_Error ATGEN_GetSMSMemories(GSM_StateMachine *s)
 		Priv->PhoneSMSMemory = AT_AVAILABLE;
 		Priv->PhoneSaveSMS = AT_AVAILABLE;
 	}
+  if (GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_SMS_SR)) {
+    smprintf(s, "Forcing support for SR storage!\n");
+    Priv->SRSMSMemory = AT_AVAILABLE;
+  }
+  if (GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_SMS_NO_SR)) {
+    smprintf(s, "Forcing to disable SR storage!\n");
+    Priv->SRSMSMemory = AT_NOTAVAILABLE;
+  }
 	if (GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_SMS_NO_ME)) {
 		smprintf(s, "Forcing to disable ME storage!\n");
 		Priv->PhoneSMSMemory = AT_NOTAVAILABLE;
@@ -346,25 +369,68 @@ GSM_Error ATGEN_GetSMSMode(GSM_StateMachine *s)
 	return error;
 }
 
+GSM_Error ATGEN_SetRequestedSMSMemory(GSM_StateMachine *s, GSM_MemoryType memoryType, gboolean writeable,
+																			GSM_Phone_RequestID requestId)
+{
+	GSM_Error error;
+	unsigned char command[20];
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+
+	if (!memoryType || memoryType == MEM_INVALID) {
+		smprintf_level(s, D_ERROR, "SMS memory type not set or invalid.\n");
+		return ERR_INVALID_OPERATION;
+	}
+
+	if (!ATGEN_IsMemoryAvailable(Priv, memoryType) ||
+			(writeable && !ATGEN_IsMemoryWriteable(Priv, memoryType)))
+	{
+		smprintf_level(s, D_ERROR, "Requested memory not available for %s: %s\n",
+									 writeable ? "writing" : "reading",
+									 GSM_MemoryTypeToString(memoryType));
+		return ERR_MEMORY_NOT_AVAILABLE;
+	}
+
+	if (Priv->SMSMemory == memoryType && Priv->SMSMemoryWrite == writeable) {
+		smprintf(s, "Requested memory type already set: %s\n",
+						 GSM_MemoryTypeToString(memoryType));
+		return ERR_NONE;
+	}
+
+	snprintf(command, 20, "AT+CPMS=\"%s\"\r", GSM_MemoryTypeToString(memoryType));
+	if (writeable) {
+		// if it's writeable we assume it's also readable
+		snprintf(command + 12, 8, ",\"%s\"\r", GSM_MemoryTypeToString(memoryType));
+	}
+
+	/* If phone encodes also values in command, we need normal charset */
+	if (Priv->EncodedCommands) {
+		error = ATGEN_SetCharset(s, AT_PREF_CHARSET_NORMAL);
+
+		if (error != ERR_NONE) {
+			return error;
+		}
+	}
+
+	smprintf(s, "Setting SMS memory to %s\n", command + 8);
+	error = ATGEN_WaitFor(s, command, strlen(command), 0x00, 20, requestId);
+
+	if(error == ERR_NONE) {
+		Priv->SMSMemory = memoryType;
+		Priv->SMSMemoryWrite = writeable;
+	}
+	return error;
+}
+
 GSM_Error ATGEN_GetSMSLocation(GSM_StateMachine *s, GSM_SMSMessage *sms, unsigned char *folderid, int *location, gboolean for_write)
 {
 	GSM_Error error;
 	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
 	int ifolderid = 0, maxfolder = 0;
 
-	if (Priv->PhoneSMSMemory == 0) {
-		error = ATGEN_SetSMSMemory(s, FALSE, for_write, (sms->Folder % 2) == 0);
-
-		if (error != ERR_NONE && error != ERR_NOTSUPPORTED) {
+	if (Priv->PhoneSMSMemory == 0 || Priv->SIMSMSMemory == 0 || Priv->SRSMSMemory == 0) {
+		error = ATGEN_GetSMSMemories(s);
+		if(error != ERR_NONE)
 			return error;
-		}
-	}
-	if (Priv->SIMSMSMemory == 0) {
-		error = ATGEN_SetSMSMemory(s, TRUE, for_write, (sms->Folder % 2) == 0);
-
-		if (error != ERR_NONE && error != ERR_NOTSUPPORTED) {
-			return error;
-		}
 	}
 
 	if (Priv->SIMSMSMemory != AT_AVAILABLE && Priv->PhoneSMSMemory != AT_AVAILABLE) {
@@ -409,6 +475,11 @@ GSM_Error ATGEN_GetSMSLocation(GSM_StateMachine *s, GSM_SMSMessage *sms, unsigne
 	}
 	smprintf(s, "SMS folder %i & location %i -> ATGEN folder %i & location %i\n",
 			sms->Folder, sms->Location, *folderid, *location);
+
+	// if needed memory type already set, use it
+	if(sms->Memory && sms->Memory != MEM_INVALID) {
+		return ATGEN_SetRequestedSMSMemory(s, sms->Memory, for_write, ID_SetMemoryType);
+	}
 
 	/* Set the needed memory type */
 	if (Priv->SIMSMSMemory == AT_AVAILABLE &&
@@ -510,7 +581,10 @@ GSM_Error ATGEN_DecodePDUMessage(GSM_StateMachine *s, const char *PDU, const int
 		} else if (buffer[parse_len] == 0x89) {
 			/* Not sure what the data here means, see tests/at-sms/39.dump */
 			smprintf(s, "Assuming we can ignore anything starting with 0x89\n");
-		} else {
+		} else if(sms->PDU == SMS_Status_Report) {
+      smprintf(s, "Assuming we can ignore extra data after successfully parsing status report\n");
+    }
+    else {
 			free(buffer);
 			return ERR_UNKNOWN;
 		}
@@ -1004,11 +1078,12 @@ GSM_Error ATGEN_GetSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms)
 
 	if (error == ERR_NONE || error == ERR_CORRUPTED) {
 		getfolder = sms->SMS[0].Folder;
-/* 		if (getfolder != 0 && getfolder != sms->SMS[0].Folder) return ERR_EMPTY; */
 		ATGEN_SetSMSLocation(s, &sms->SMS[0], folderid, location);
 		sms->SMS[0].Folder = getfolder;
-		sms->SMS[0].Memory = MEM_SM;
-		if (getfolder > 2) sms->SMS[0].Memory = MEM_ME;
+		if(sms->SMS[0].Memory != MEM_SR) {
+			sms->SMS[0].Memory = MEM_SM;
+			if (getfolder > 2) sms->SMS[0].Memory = MEM_ME;
+		}
 	}
  fail:
 	if (oldmode != Priv->SMSMode) {
@@ -2181,6 +2256,7 @@ GSM_Error ATGEN_DeleteSMS(GSM_StateMachine *s, GSM_SMSMessage *sms)
 {
 	GSM_Error error;
 	GSM_MultiSMSMessage msms;
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
 	unsigned char req[20] = {'\0'}, folderid = 0;
 	int location = 0, length = 0;
 
@@ -2193,7 +2269,9 @@ GSM_Error ATGEN_DeleteSMS(GSM_StateMachine *s, GSM_SMSMessage *sms)
 	if (error != ERR_NONE && error != ERR_CORRUPTED) {
 		return error;
 	}
-	error = ATGEN_GetSMSLocation(s, sms, &folderid, &location, TRUE);
+
+	error = ATGEN_GetSMSLocation(s, sms, &folderid, &location,
+			ATGEN_IsMemoryWriteable(Priv, sms->Memory));
 
 	if (error != ERR_NONE) {
 		return error;
@@ -2272,65 +2350,63 @@ GSM_Error ATGEN_SetFastSMSSending(GSM_StateMachine *s, gboolean enable)
 
 GSM_Error ATGEN_IncomingSMSInfo(GSM_Protocol_Message *msg, GSM_StateMachine *s)
 {
-	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
-	GSM_Phone_Data *Data = &s->Phone.Data;
-	GSM_SMSMessage sms;
+  GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+  char *buffer = msg->Buffer;
+  GSM_SMSMessage sms;
+  GSM_Error error;
 
-	/* We get here: +CMTI: SM, 19 */
-	char *buffer = NULL;
+  char mem_tag[3]; // eg: "SM\0"
+  const size_t cmd_len = 6;
+
+	if(!s->User.IncomingSMS || !s->Phone.Data.EnableIncomingSMS)
+		return ERR_NONE;
 
 	memset(&sms, 0, sizeof(sms));
-	smprintf(s, "Incoming SMS\n");
+  sms.State 	 = 0;
+  sms.InboxFolder  = TRUE;
+  sms.PDU 	 = 0;
 
-	if (Data->EnableIncomingSMS && s->User.IncomingSMS != NULL) {
-		sms.State 	 = 0;
-		sms.InboxFolder  = TRUE;
-		sms.PDU 	 = 0;
+  if(strncmp(buffer, "+CMTI:", cmd_len) == 0) {
+    smprintf(s, "Incoming SMS information\n");
+  }
+  else if(strncmp(buffer, "+CDSI:", cmd_len) == 0) {
+    smprintf(s, "Incoming SMS status report information\n");
+    sms.PDU = SMS_Status_Report;
+  }
+  else {
+    smprintf(s, "Unrecognised response\n");
+    return ERR_UNKNOWNRESPONSE;
+  }
 
-		buffer = strchr(msg->Buffer, ':');
+  error = ATGEN_ParseReply(s, buffer + cmd_len, " @r, @i",
+                           &mem_tag, sizeof(mem_tag),
+                           &sms.Location);
+  if (error != ERR_NONE)
+    return error;
 
-		if (buffer == NULL) {
-			return ERR_UNKNOWNRESPONSE;
-		}
-		buffer++;
+  sms.Memory = GSM_StringToMemoryType(mem_tag);
+  if (!ATGEN_IsMemoryAvailable(Priv, sms.Memory)) {
+		smprintf(s, "Incoming SMS information ignored as %s memory is disabled\n", mem_tag);
+		return ERR_NONE;
+  }
 
-		while (isspace((int)*buffer)) {
-			buffer++;
-		}
-		if (strncmp(buffer, "ME", 2) == 0 || strncmp(buffer, "\"ME\"", 4) == 0) {
-			if (Priv->SIMSMSMemory == AT_AVAILABLE) {
-				sms.Folder = 3;
-			} else {
-				sms.Folder = 1;
-			}
-		} else if (strncmp(buffer, "MT", 2) == 0 || strncmp(buffer, "\"MT\"", 4) == 0) {
-			if (Priv->SIMSMSMemory == AT_AVAILABLE) {
-				sms.Folder = 3;
-			} else {
-				sms.Folder = 1;
-			}
-		} else if (strncmp(buffer, "SM", 2) == 0 || strncmp(buffer, "\"SM\"", 4) == 0) {
-			sms.Folder = 1;
-		} else if (strncmp(buffer, "SR", 2) == 0 || strncmp(buffer, "\"SR\"", 4) == 0) {
-			sms.Folder = 1;
-			sms.PDU = SMS_Status_Report;
-		} else {
-			return ERR_UNKNOWNRESPONSE;
-		}
-		buffer = strchr(msg->Buffer, ',');
+  switch(sms.Memory) {
+    case MEM_ME:
+    case MEM_MT:
+      sms.Folder = Priv->SIMSMSMemory == AT_AVAILABLE ? 3 : 1;
+      break;
+    case MEM_SM:
+    case MEM_SR:
+      sms.Folder = 1;
+      break;
+    default:
+      smprintf(s, "Unsupported memory type\n");
+      return ERR_NOTSUPPORTED;
+  }
 
-		if (buffer == NULL) {
-			return ERR_UNKNOWNRESPONSE;
-		}
-		buffer++;
+  s->User.IncomingSMS(s, &sms, s->User.IncomingSMSUserData);
 
-		while (isspace((int)*buffer)) {
-			buffer++;
-		}
-		sms.Location = atoi(buffer);
-		s->User.IncomingSMS(s, &sms, s->User.IncomingSMSUserData);
-	}
-	return ERR_NONE;
+  return ERR_NONE;
 }
 
 GSM_Error ATGEN_IncomingSMSDeliver(GSM_Protocol_Message *msg, GSM_StateMachine *s)

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -282,6 +282,24 @@ static ATErrorCode CMEErrorCodes[] = {
 
 static char samsung_location_error[] = "[Samsung] Empty location";
 
+gboolean ATGEN_IsMemoryAvailable(const GSM_Phone_ATGENData *data, GSM_MemoryType type)
+{
+	return
+			(type == MEM_ME && data->PhoneSMSMemory == AT_AVAILABLE) ||
+			(type == MEM_SM && data->SIMSMSMemory == AT_AVAILABLE) ||
+			(type == MEM_MT && (data->PhoneSMSMemory == AT_AVAILABLE || data->SIMSMSMemory == AT_AVAILABLE)) ||
+			(type == MEM_SR && data->SRSMSMemory == AT_AVAILABLE);
+}
+
+gboolean ATGEN_IsMemoryWriteable(const GSM_Phone_ATGENData *data, GSM_MemoryType type)
+{
+	// we assume that if memory is writeable, then it's also enabled
+	return
+			(type == MEM_ME && data->PhoneSaveSMS == AT_AVAILABLE) ||
+			(type == MEM_SM && data->SIMSaveSMS == AT_AVAILABLE) ||
+			(type == MEM_MT && (data->PhoneSaveSMS == AT_AVAILABLE || data->SIMSaveSMS == AT_AVAILABLE)) ||
+			(type == MEM_SR && data->SRSaveSMS == AT_AVAILABLE);
+}
 
 GSM_Error ATGEN_HandleCMEError(GSM_StateMachine *s)
 {
@@ -6265,7 +6283,7 @@ GSM_Reply_Function ATGENReplyFunctions[] = {
 {ATGEN_GenericReplyIgnore, 	"+ZUSIMR:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+SPNWNAME:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+ZEND"			,0x00,0x00,ID_IncomingFrame	 },
-{ATGEN_GenericReplyIgnore, 	"+CDSI:"		,0x00,0x00,ID_IncomingFrame	 },
+{ATGEN_IncomingSMSInfo,		  "+CDSI:" 	 	,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore,	"+CLCC:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore,	"#STN:"			,0x00,0x00,ID_IncomingFrame	 },
 

--- a/libgammu/phone/at/atgen.h
+++ b/libgammu/phone/at/atgen.h
@@ -229,6 +229,15 @@ typedef struct {
 } GSM_AT_SMS_Cache;
 
 /**
+ * Structure for SMS Info cache.
+ */
+typedef struct {
+	size_t cache_size;
+	unsigned int cache_used;
+	GSM_SMSMessage *smsInfo_records;
+} GSM_AT_SMSInfo_Cache;
+
+/**
  * Maximal length of phonebook memories list.
  */
 #define AT_PBK_MAX_MEMORIES	200
@@ -397,12 +406,55 @@ typedef struct {
 	 * Mode of SQWE (Siemens phones and switching to OBEX).
 	 */
 	int			SQWEMode;
-	/**
-	 * Screen width and heigth for screenshot.
-	 */
+  /**
+   * Screen width and height for screenshot.
+   */
 	int			ScreenWidth;
 	int			ScreenHeigth;
+  /**
+   * Is phone SR memory available ?
+   */
+  GSM_AT_Feature		SRSMSMemory;
+  /**
+   * Can we write to phone SR memory?
+   */
+  GSM_AT_Feature		SRSaveSMS;
+	/**
+	 * Cache for incoming SMS info.
+	 */
+	GSM_AT_SMSInfo_Cache SMSInfoCache;
 } GSM_Phone_ATGENData;
+
+/**
+ * Determine if the memory type is available.
+ *
+ * \param data AT generic phone data.
+ * \param type GSM memory type to check.
+ *
+ * \return TRUE if the memory is available.
+ */
+gboolean ATGEN_IsMemoryAvailable (const GSM_Phone_ATGENData *data, GSM_MemoryType type);
+
+/**
+ * Determine if the memory is configured for writing.
+ *
+ * \param data AT generic phone data.
+ * \param type GSM memory type to check.
+ *
+ * \return TRUE if the memory can be written to.
+ */
+gboolean ATGEN_IsMemoryWriteable(const GSM_Phone_ATGENData *data, GSM_MemoryType type);
+
+/**
+ * Sets the requested memory type on the MT
+ *
+ * @param s State machine (SM) structure
+ * @param memoryType The memory type to set
+ * @param writeable Request memory set to writeable
+ * @param requestId The request ID for SM routing, usually ID_SetMemoryType
+ */
+GSM_Error ATGEN_SetRequestedSMSMemory(GSM_StateMachine *s, GSM_MemoryType memoryType, gboolean writeable,
+                                      GSM_Phone_RequestID requestId);
 
 /**
  * Generates error code from current CMS error according to

--- a/libgammu/service/gsmpbk.c
+++ b/libgammu/service/gsmpbk.c
@@ -16,6 +16,7 @@
 GSM_MemoryType GSM_StringToMemoryType(const char *s) {
     if (strcmp(s, "ME") == 0)      return MEM_ME;
     else if (strcmp(s, "SM") == 0) return MEM_SM;
+		else if (strcmp(s, "SR") == 0) return MEM_SR;
     else if (strcmp(s, "ON") == 0) return MEM_ON;
     else if (strcmp(s, "DC") == 0) return MEM_DC;
     else if (strcmp(s, "RC") == 0) return MEM_RC;

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -2054,6 +2054,7 @@ void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *u
         SMSD_Log(DEBUG_ERROR, Config, "failed to reallocate SMS information cache, some records will be lost.");
         return;
       }
+      Cache->smsInfo_records = reallocated;
       Cache->cache_size *= 2;
     }
   }
@@ -2106,7 +2107,7 @@ GSM_Error SMSD_ProcessSMSInfoCache(GSM_SMSDConfig *Config)
 		sms->Memory = MEM_INVALID;
 	}
 
-	/* cache processed successfully, clear it for reuse */
+	/* cache processed successfully, reset used count to reuse cache memory */
 	if(error == ERR_NONE)
 		Cache->cache_used = 0;
 

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -60,6 +60,8 @@
 #endif
 
 #include "../libgammu/misc/string.h"
+#include "../libgammu/protocol/protocol.h"
+#include "../libgammu/gsmstate.h"
 
 #ifndef PATH_MAX
 #ifdef MAX_PATH
@@ -2015,6 +2017,102 @@ void SMSD_IncomingUSSDCallback(GSM_StateMachine *sm UNUSED, GSM_USSDMessage *uss
 	}
 }
 
+#define INIT_SMSINFO_CACHE_SIZE 10
+/**
+ * Called when a +CDSI or +CMTI event is received.
+ *
+ * SMSD uses polling to read messages from MT memory, to avoid potential
+ * conflicts only information on status reports stored in SR memory is cached.
+ *
+ * The amount of SR memory on a device is generally very small so it's unlikely
+ * there would be an issue creating/reallocating the cache, if such an issue
+ * occurs some or all status report information records will be lost.
+ */
+void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *user_data)
+{
+  GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+  GSM_AT_SMSInfo_Cache *Cache = &Priv->SMSInfoCache;
+  GSM_SMSDConfig *Config = user_data;
+  void *reallocated = NULL;
+
+  if (sms->PDU != SMS_Status_Report || sms->Memory != MEM_SR)
+    return;
+
+  SMSD_Log(DEBUG_INFO, Config, "caching incoming status report information.");
+
+  if (Cache->cache_size <= Cache->cache_used) {
+    if (Cache->smsInfo_records == NULL) {
+      Cache->smsInfo_records = malloc(INIT_SMSINFO_CACHE_SIZE * sizeof(*Cache->smsInfo_records));
+      if (Cache->smsInfo_records == NULL) {
+        SMSD_Log(DEBUG_ERROR, Config, "failed to allocate SMS information cache, records will not be processed.");
+        return;
+      }
+      Cache->cache_size = INIT_SMSINFO_CACHE_SIZE;
+    } else {
+      reallocated = realloc(Cache->smsInfo_records, (Cache->cache_size * 2) * sizeof(*Cache->smsInfo_records));
+      if (reallocated == NULL) {
+        SMSD_Log(DEBUG_ERROR, Config, "failed to reallocate SMS information cache, some records will be lost.");
+        return;
+      }
+      Cache->cache_size *= 2;
+    }
+  }
+
+  memcpy(Cache->smsInfo_records + Cache->cache_used, sms, sizeof(*Cache->smsInfo_records));
+  Cache->cache_used += 1;
+}
+
+GSM_Error SMSD_ProcessSMSInfoCache(GSM_SMSDConfig *Config)
+{
+	GSM_StateMachine *s = Config->gsm;
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+	GSM_AT_SMSInfo_Cache *Cache = &Priv->SMSInfoCache;
+	GSM_MultiSMSMessage msms;
+	GSM_SMSMessage *sms;
+	GSM_Error error = ERR_NONE;
+	unsigned int i;
+
+	memset(&msms, 0, sizeof(GSM_MultiSMSMessage));
+	msms.Number = 1;
+
+	for(i = 0; i < Cache->cache_used; ++i) {
+		sms = Cache->smsInfo_records + i;
+		if(sms->Memory == MEM_INVALID) continue;
+
+		msms.SMS[0] = *sms;
+
+		error = GSM_GetSMS(s, &msms);
+		if(error != ERR_NONE) {
+			SMSD_Log(DEBUG_ERROR, Config, "Error reading SMS from memory %s:%d",
+					GSM_MemoryTypeToString(sms->Memory),
+					sms->Location);
+			break;
+		}
+
+		error = SMSD_ProcessSMS(Config, &msms);
+		if(error != ERR_NONE) {
+			SMSD_LogError(DEBUG_ERROR, Config, "Error processing SMS", error);
+			break;
+		}
+
+		error = GSM_DeleteSMS(s, sms);
+		if (error != ERR_NONE) {
+			SMSD_LogError(DEBUG_ERROR, Config, "Error deleting SMS", error);
+			break;
+		}
+
+		/* successfully processed cache entry, mark invalid to avoid reprocessing
+		 * in case of retry loop */
+		sms->Memory = MEM_INVALID;
+	}
+
+	/* cache processed successfully, clear it for reuse */
+	if(error == ERR_NONE)
+		Cache->cache_used = 0;
+
+	return error;
+}
+
 /**
  * Main loop which takes care of connection to phone and processing of
  * messages.
@@ -2091,9 +2189,10 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 					GSM_SetIncomingCall(Config->gsm, TRUE);
 				}
 
+				GSM_SetIncomingSMSCallback(Config->gsm, SMSD_IncomingSMSCallback, Config);
+
 				/* We use polling so store messages to SIM */
 				GSM_SetIncomingSMS(Config->gsm, TRUE);
-
 				GSM_SetIncomingUSSDCallback(Config->gsm, SMSD_IncomingUSSDCallback, Config);
 				GSM_SetIncomingUSSD(Config->gsm, TRUE);
 
@@ -2135,8 +2234,7 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 				}
 				break;
 			case ERR_DEVICEOPENERROR:
-				SMSD_Terminate(Config, "Can't open device",
-						error, TRUE, -1);
+				SMSD_Terminate(Config, "Can't open device",	error, TRUE, -1);
 				goto done;
 			default:
 				SMSD_LogError(DEBUG_INFO, Config, "Error at init connection", error);
@@ -2163,6 +2261,14 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 
 			initerrors = 0;
 
+			/* process SMS info cache */
+			if(!SMSD_ProcessSMSInfoCache(Config)) {
+				errors++;
+				continue;
+			} else {
+				errors = 0;
+			}
+
 			/* read all incoming SMS */
 			if (!SMSD_CheckSMSStatus(Config)) {
 				errors++;
@@ -2172,7 +2278,6 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 			}
 
 		}
-
 
 		/* time for preventive reset */
 		if (Config->resetfrequency > 0 && difftime(lastloop, lastreset) >= Config->resetfrequency) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ endif (EXECUTABLE_OUTPUT_PATH)
 # We use Gammu
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../include")
 
+# ATGEN function tests
+add_subdirectory(atgen)
+
 # Basic check for statemachine allocation
 add_executable(statemachine-alloc statemachine-alloc.c)
 add_coverage(statemachine-alloc)
@@ -545,7 +548,7 @@ if (WITH_ATGEN)
             "${GAMMU_TEST_PATH}/at-get-smsmemories${CMAKE_EXECUTABLE_SUFFIX}"
             "${Gammu_SOURCE_DIR}/tests/at-cpms/${TESTMESSAGE}")
         set_tests_properties("at-get-smsmemories-${TESTNAME}" PROPERTIES
-            PASS_REGULAR_EXPRESSION "read: ME : ok, SM : ok, save: ME : ok, SM = ok")
+            PASS_REGULAR_EXPRESSION "read: ME : ok, SM : ok, SR : N/A save: ME : ok, SM : ok, SR : N/A")
     endforeach(TESTMESSAGE $MESSAGES)
 
     # List test cases for just SM
@@ -560,7 +563,22 @@ if (WITH_ATGEN)
             "${GAMMU_TEST_PATH}/at-get-smsmemories${CMAKE_EXECUTABLE_SUFFIX}"
             "${Gammu_SOURCE_DIR}/tests/at-cpms-sm/${TESTMESSAGE}")
         set_tests_properties("at-get-smsmemories-sm-${TESTNAME}" PROPERTIES
-            PASS_REGULAR_EXPRESSION "read: ME : N/A, SM : ok, save: ME : N/A, SM = ok")
+            PASS_REGULAR_EXPRESSION "read: ME : N/A, SM : ok, SR : N/A save: ME : N/A, SM : ok, SR : N/A")
+    endforeach(TESTMESSAGE $MESSAGES)
+
+    # List test cases for just SR
+    file(GLOB MESSAGES
+            RELATIVE "${Gammu_SOURCE_DIR}/tests/at-cpms-sr"
+            "${Gammu_SOURCE_DIR}/tests/at-cpms-sr/*.dump")
+    list(SORT MESSAGES)
+
+    foreach(TESTMESSAGE ${MESSAGES})
+        string(REPLACE .dump "" TESTNAME ${TESTMESSAGE})
+        add_test("at-get-smsmemories-sr-${TESTNAME}"
+                "${GAMMU_TEST_PATH}/at-get-smsmemories${CMAKE_EXECUTABLE_SUFFIX}"
+                "${Gammu_SOURCE_DIR}/tests/at-cpms-sr/${TESTMESSAGE}")
+        set_tests_properties("at-get-smsmemories-sr-${TESTNAME}" PROPERTIES
+                PASS_REGULAR_EXPRESSION "read: ME : ok, SM : N/A, SR : ok save: ME : ok, SM : N/A, SR : ok")
     endforeach(TESTMESSAGE $MESSAGES)
 
     # AT CNMI parsing

--- a/tests/at-cpms-sr/generic.dump
+++ b/tests/at-cpms-sr/generic.dump
@@ -1,0 +1,4 @@
+AT+CPMS=?
++CPMS: (ME", "SR"), ("ME", "SR"), ("ME")
+OK
+

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(atgen-tests test_helper.c)
+add_library(atgen-tests STATIC test_helper.c)
 target_link_libraries(atgen-tests libGammu)
 
 if(MYSQL_INCLUDE_DIR)

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_library(atgen-tests test_helper.c)
+target_link_libraries(atgen-tests libGammu)
+
+if(MYSQL_INCLUDE_DIR)
+    include_directories(${MYSQL_INCLUDE_DIR})
+endif()
+
+if(POSTGRES_INCLUDE_DIR)
+    include_directories(${POSTGRES_INCLUDE_DIR})
+endif()
+
+MACRO(atgen_test TEST_NAME)
+    add_executable(${TEST_NAME} ${TEST_NAME}.c)
+    add_coverage(${TEST_NAME})
+    target_link_libraries(${TEST_NAME} atgen-tests ${LIBINTL_LIBRARIES})
+    add_test(${TEST_NAME} "${GAMMU_TEST_PATH}/atgen/${TEST_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+ENDMACRO(atgen_test)
+
+MACRO(smsd_test TEST_NAME)
+    add_executable(${TEST_NAME} ${TEST_NAME}.c)
+    add_coverage(${TEST_NAME})
+    target_link_libraries(${TEST_NAME} atgen-tests gsmsd ${LIBINTL_LIBRARIES})
+    add_test(${TEST_NAME} "${GAMMU_TEST_PATH}/atgen/${TEST_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+ENDMACRO(smsd_test)
+
+atgen_test(is-memory-enabled)
+atgen_test(is-memory-writeable)
+atgen_test(set-requested-sms-memory)
+atgen_test(incoming-sms-info)
+
+atgen_test(get-sms-location)
+atgen_test(get-sms)

--- a/tests/atgen/get-sms-location.c
+++ b/tests/atgen/get-sms-location.c
@@ -8,7 +8,7 @@ GSM_Error ATGEN_GetSMSMemories(GSM_StateMachine *s);
 GSM_Error ATGEN_GetSMSLocation(GSM_StateMachine *s, GSM_SMSMessage *sms,
     unsigned char *folderid, int *location, gboolean for_write);
 
-void requested_memory()
+void requested_memory(void)
 {
   GSM_Error error;
   GSM_SMSMessage sms;
@@ -30,6 +30,8 @@ void requested_memory()
 
   puts(__func__);
 
+  UNNEEDED(Priv);
+
   memset(&sms, 0, sizeof(sms));
   sms.Memory = MEM_SR;
   sms.Folder = 0;
@@ -44,7 +46,7 @@ void requested_memory()
   test_result(location == 3);
 }
 
-void computed_memory()
+void computed_memory(void)
 {
   GSM_Error error;
   GSM_SMSMessage sms;
@@ -65,6 +67,8 @@ void computed_memory()
   bind_response_handling(s);
 
   puts(__func__);
+
+  UNNEEDED(Priv);
 
   memset(&sms, 0, sizeof(sms));
   sms.Folder = 0;

--- a/tests/atgen/get-sms-location.c
+++ b/tests/atgen/get-sms-location.c
@@ -1,0 +1,86 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+
+#include "../../libgammu/phone/at/atgen.h"
+#include "../../libgammu/gsmstate.h"
+
+GSM_Error ATGEN_GetSMSMemories(GSM_StateMachine *s);
+GSM_Error ATGEN_GetSMSLocation(GSM_StateMachine *s, GSM_SMSMessage *sms,
+    unsigned char *folderid, int *location, gboolean for_write);
+
+void requested_memory()
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  unsigned char folderid = 0;
+  int location = 0;
+  const char *responses[] = {
+      // GetSMSMemories
+      "+CPMS: (\"ME\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      // SetRequestedSMSMemory
+      "+CPMS: 2,4,0,4,0,4\r",
+      "OK\r\n",
+
+      "ERROR\r\n", };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  sms.Memory = MEM_SR;
+  sms.Folder = 0;
+  sms.Location = 3;
+
+  s->Phone.Data.RequestID = ID_None;
+  ATGEN_GetSMSMemories(s);
+
+  error = ATGEN_GetSMSLocation(s, &sms, &folderid, &location, FALSE);
+  test_result(error == ERR_NONE);
+  test_result(sms.Memory == MEM_SR)
+  test_result(location == 3);
+}
+
+void computed_memory()
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  unsigned char folderid = 0;
+  int location = 0;
+  const char *responses[] = {
+      // GetSMSMemories
+      "+CPMS: (\"ME\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      // SetSMSMemory
+      "+CPMS: 2,4,0,4,0,4\r",
+      "OK\r\n",
+
+      "ERROR\r\n", };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  sms.Folder = 0;
+  sms.Location = 100002;
+
+  s->Phone.Data.RequestID = ID_None;
+  ATGEN_GetSMSMemories(s);
+
+  error = ATGEN_GetSMSLocation(s, &sms, &folderid, &location, FALSE);
+  test_result(error == ERR_NONE);
+  test_result(sms.Memory == MEM_ME)
+  test_result(location == 2);
+}
+
+int main(void)
+{
+  requested_memory();
+  computed_memory();
+}

--- a/tests/atgen/get-sms.c
+++ b/tests/atgen/get-sms.c
@@ -26,6 +26,8 @@ void get_sms_default_memory(void)
 
   puts(__func__);
 
+  UNNEEDED(Priv);
+
   sms->Location = 0;
   sms->Folder = 1;
 
@@ -58,6 +60,8 @@ void get_sms_requested_memory(void)
   bind_response_handling(s);
 
   puts(__func__);
+
+  UNNEEDED(Priv);
 
   sms->Memory = MEM_SR;
   sms->Location = 0;

--- a/tests/atgen/get-sms.c
+++ b/tests/atgen/get-sms.c
@@ -1,0 +1,77 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+
+GSM_Error ATGEN_GetSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms);
+
+void get_sms_default_memory(void)
+{
+  GSM_Error error;
+  GSM_MultiSMSMessage msms;
+  GSM_SMSMessage *sms = &msms.SMS[0];
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = {
+      "+CPMS: (\"ME\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      "+CPMS: 0,255,0,255,0,255\r",
+      "OK\r\n",
+      "+CMGR: 0,,23\r",
+      "0006D60B911623480736F4111011719551401110117195714000\r",
+      "OK\r\n",
+
+      "ERROR\r\n"
+  };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  sms->Location = 0;
+  sms->Folder = 1;
+
+  error = ATGEN_GetSMS(s, &msms);
+  test_result(error == ERR_NONE);
+  test_result(sms->Memory == MEM_SM);
+
+  cleanup_state_machine(s);
+}
+
+void get_sms_requested_memory(void)
+{
+  GSM_Error error;
+  GSM_MultiSMSMessage msms;
+  GSM_SMSMessage *sms = &msms.SMS[0];
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = {
+      "+CPMS: (\"ME\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      "+CPMS: 0,255,0,255,0,255\r",
+      "OK\r\n",
+      "+CMGR: 0,,23\r",
+      "0006D60B919345980736F4111011719551401110117195714000\r",
+      "OK\r\n",
+
+      "ERROR\r\n"
+  };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  sms->Memory = MEM_SR;
+  sms->Location = 0;
+  sms->Folder = 1;
+
+  error = ATGEN_GetSMS(s, &msms);
+  test_result(error == ERR_NONE);
+  test_result(sms->Memory == MEM_SR);
+
+  cleanup_state_machine(s);
+}
+
+int main(void)
+{
+  get_sms_default_memory();
+  get_sms_requested_memory();
+}

--- a/tests/atgen/incoming-sms-info.c
+++ b/tests/atgen/incoming-sms-info.c
@@ -1,0 +1,223 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+#include "../../libgammu/phone/at/atgen.h"
+#include "../../libgammu/gsmstate.h"
+
+int is_empty(const char *buffer, size_t length)
+{
+  if(buffer != NULL && length > 0)
+    for(size_t i = 0; i < length; ++i)
+      if(buffer[i] != '\0') return FALSE;
+
+  return TRUE;
+}
+
+void IncomingSMS(GSM_StateMachine * s, GSM_SMSMessage *sms, void *user_data)
+{
+  GSM_MultiSMSMessage msms;
+  msms.SMS[0] = *sms;
+  msms.Number = 1;
+
+  GSM_GetSMS(s, &msms);
+  if(user_data != NULL)
+    memcpy(user_data, &msms.SMS[0], sizeof(GSM_SMSMessage));
+}
+
+void ignore_if_incoming_sms_disabled(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
+  GSM_Protocol_Message msg;
+
+  char *event = "+CDSI: \"SR\",0\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = FALSE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(is_empty((char*)&sms, sizeof(sms)));
+
+  cleanup_state_machine(s);
+}
+
+void ignore_if_no_handler(void)
+{
+  GSM_Error error;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
+  GSM_Protocol_Message msg;
+
+  char *event = "+CDSI: \"SR\",0\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+
+  msg.Length = strlen(event);
+  msg.Buffer = event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+
+  cleanup_state_machine(s);
+}
+
+void skip_if_memory_disabled(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
+  GSM_Protocol_Message msg;
+
+  char *event = "+CDSI: \"SR\",0\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  Priv->SRSMSMemory = AT_NOTAVAILABLE;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(is_empty((char*)&sms, sizeof(sms)));
+
+  cleanup_state_machine(s);
+}
+
+void cdsi_sr_0(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
+  GSM_Protocol_Message msg;
+
+  char *event = "+CDSI: \"SR\",0\r";
+
+  const char *responses[] = {
+      "+CPMS: (\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"MT\",\"SM\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      "+CPMS: 0,255,0,255,0,255\r",
+      "OK\r\n",
+      "+CMGR: 1,,28\r",
+      "0006D60B911326880736F4111011719551401110117195714000\r",
+      "OK\r\n",
+  };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  Priv->SRSMSMemory = AT_AVAILABLE;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(sms.Location == 0);
+  test_result(sms.Memory == MEM_SR);
+  test_result(sms.PDU == SMS_Status_Report);
+
+  cleanup_state_machine(s);
+}
+
+void cmti_sm_1(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
+  GSM_Protocol_Message msg;
+
+  char *event = "+CDSI: \"SM\",1\r\n";
+
+  const char *responses[] = {
+      "+CPMS: (\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
+      "OK\r\n",
+      "+CPMS: 0,255,0,255,0,255\r",
+      "OK\r\n",
+      "+CMGR: 1,,23\r",
+      "07918497483252F0040B918496445078F700007121320144744004D4F29C0E\r",
+      "OK\r\n",
+  };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  Priv->SIMSMSMemory = AT_AVAILABLE;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(sms.Location == 1);
+  test_result(sms.Memory == MEM_SM);
+  test_result(sms.PDU == SMS_Deliver);
+
+  cleanup_state_machine(s);
+}
+
+int main(void)
+{
+  ignore_if_incoming_sms_disabled();
+  ignore_if_no_handler();
+  skip_if_memory_disabled();
+  cdsi_sr_0();
+  cmti_sm_1();
+}

--- a/tests/atgen/incoming-sms-info.c
+++ b/tests/atgen/incoming-sms-info.c
@@ -5,8 +5,10 @@
 
 int is_empty(const char *buffer, size_t length)
 {
+  size_t i;
+
   if(buffer != NULL && length > 0)
-    for(size_t i = 0; i < length; ++i)
+    for(i = 0; i < length; ++i)
       if(buffer[i] != '\0') return FALSE;
 
   return TRUE;

--- a/tests/atgen/incoming-sms-info.c
+++ b/tests/atgen/incoming-sms-info.c
@@ -29,15 +29,16 @@ void ignore_if_incoming_sms_disabled(void)
   GSM_SMSMessage sms;
   GSM_StateMachine *s = setup_state_machine();
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
-  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
   GSM_Protocol_Message msg;
 
-  char *event = "+CDSI: \"SR\",0\r";
+  const char *event = "+CDSI: \"SR\",0\r";
   const char *responses[] = { "ERROR\r\n" };
   SET_RESPONSES(responses);
   bind_response_handling(s);
 
   puts(__func__);
+
+  UNNEEDED(Priv);
 
   memset(&sms, 0, sizeof(sms));
   s->Phone.Data.EnableIncomingSMS = FALSE;
@@ -46,7 +47,7 @@ void ignore_if_incoming_sms_disabled(void)
   s->User.IncomingSMSUserData = &sms;
 
   msg.Length = strlen(event);
-  msg.Buffer = event;
+  msg.Buffer = (char*)event;
   msg.Type = 0;
 
   s->Phone.Data.RequestMsg = &msg;
@@ -62,21 +63,22 @@ void ignore_if_no_handler(void)
   GSM_Error error;
   GSM_StateMachine *s = setup_state_machine();
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
-  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
   GSM_Protocol_Message msg;
 
-  char *event = "+CDSI: \"SR\",0\r";
+  const char *event = "+CDSI: \"SR\",0\r";
   const char *responses[] = { "ERROR\r\n" };
   SET_RESPONSES(responses);
   bind_response_handling(s);
 
   puts(__func__);
 
+  UNNEEDED(Priv);
+
   s->Phone.Data.EnableIncomingSMS = TRUE;
   s->Phone.Data.RequestID = ID_None;
 
   msg.Length = strlen(event);
-  msg.Buffer = event;
+  msg.Buffer = (char*)event;
   msg.Type = 0;
 
   s->Phone.Data.RequestMsg = &msg;
@@ -92,10 +94,9 @@ void skip_if_memory_disabled(void)
   GSM_SMSMessage sms;
   GSM_StateMachine *s = setup_state_machine();
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
-  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
   GSM_Protocol_Message msg;
 
-  char *event = "+CDSI: \"SR\",0\r";
+  const char *event = "+CDSI: \"SR\",0\r";
   const char *responses[] = { "ERROR\r\n" };
   SET_RESPONSES(responses);
   bind_response_handling(s);
@@ -109,7 +110,7 @@ void skip_if_memory_disabled(void)
   s->User.IncomingSMSUserData = &sms;
 
   msg.Length = strlen(event);
-  msg.Buffer = event;
+  msg.Buffer = (char*)event;
   msg.Type = 0;
 
   s->Phone.Data.RequestMsg = &msg;
@@ -127,10 +128,9 @@ void cdsi_sr_0(void)
   GSM_SMSMessage sms;
   GSM_StateMachine *s = setup_state_machine();
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
-  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
   GSM_Protocol_Message msg;
 
-  char *event = "+CDSI: \"SR\",0\r";
+  const char *event = "+CDSI: \"SR\",0\r";
 
   const char *responses[] = {
       "+CPMS: (\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"MT\",\"SM\"),(\"ME\",\"SM\")\r",
@@ -153,7 +153,7 @@ void cdsi_sr_0(void)
   s->User.IncomingSMSUserData = &sms;
 
   msg.Length = strlen(event);
-  msg.Buffer = event;
+  msg.Buffer = (char*)event;
   msg.Type = 0;
 
   s->Phone.Data.RequestMsg = &msg;
@@ -173,10 +173,9 @@ void cmti_sm_1(void)
   GSM_SMSMessage sms;
   GSM_StateMachine *s = setup_state_machine();
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
-  GSM_Protocol_ATData *d = &s->Protocol.Data.AT;
   GSM_Protocol_Message msg;
 
-  char *event = "+CDSI: \"SM\",1\r\n";
+  const char *event = "+CDSI: \"SM\",1\r\n";
 
   const char *responses[] = {
       "+CPMS: (\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
@@ -199,7 +198,7 @@ void cmti_sm_1(void)
   s->User.IncomingSMSUserData = &sms;
 
   msg.Length = strlen(event);
-  msg.Buffer = event;
+  msg.Buffer = (char*)event;
   msg.Type = 0;
 
   s->Phone.Data.RequestMsg = &msg;

--- a/tests/atgen/is-memory-enabled.c
+++ b/tests/atgen/is-memory-enabled.c
@@ -1,0 +1,43 @@
+#include "test_helper.h"
+
+int main(void)
+{
+  GSM_Phone_ATGENData data;
+
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == FALSE);
+
+  data.PhoneSMSMemory = AT_NOTAVAILABLE;
+  data.SIMSMSMemory = AT_NOTAVAILABLE;
+  data.SRSMSMemory = AT_NOTAVAILABLE;
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == FALSE);
+
+  data.PhoneSMSMemory = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == TRUE);
+
+  data.SIMSMSMemory = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == TRUE);
+
+  data.SRSMSMemory = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == TRUE);
+
+  data.PhoneSMSMemory = AT_NOTAVAILABLE;
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == FALSE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_SM) == TRUE);
+  test_result(ATGEN_IsMemoryAvailable(&data, MEM_MT) == TRUE);
+}

--- a/tests/atgen/is-memory-enabled.c
+++ b/tests/atgen/is-memory-enabled.c
@@ -3,6 +3,7 @@
 int main(void)
 {
   GSM_Phone_ATGENData data;
+  memset(&data, 0, sizeof(GSM_Phone_ATGENData));
 
   test_result(ATGEN_IsMemoryAvailable(&data, MEM_ME) == FALSE);
   test_result(ATGEN_IsMemoryAvailable(&data, MEM_SR) == FALSE);

--- a/tests/atgen/is-memory-writeable.c
+++ b/tests/atgen/is-memory-writeable.c
@@ -3,7 +3,8 @@
 int main(void)
 {
   GSM_Phone_ATGENData data;
-  
+  memset(&data, 0, sizeof(GSM_Phone_ATGENData));
+
   test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == FALSE);
   test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == FALSE);
   test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == FALSE);

--- a/tests/atgen/is-memory-writeable.c
+++ b/tests/atgen/is-memory-writeable.c
@@ -1,0 +1,43 @@
+#include "test_helper.h"
+
+int main(void)
+{
+  GSM_Phone_ATGENData data;
+  
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == FALSE);
+  
+  data.PhoneSaveSMS = AT_NOTAVAILABLE;
+  data.SRSaveSMS = AT_NOTAVAILABLE;
+  data.SIMSaveSMS = AT_NOTAVAILABLE;
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == FALSE);
+
+  data.PhoneSaveSMS = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == TRUE);
+
+  data.SIMSaveSMS = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == TRUE);
+
+  data.SRSaveSMS = AT_AVAILABLE;
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == TRUE);
+
+  data.SIMSaveSMS = AT_NOTAVAILABLE;
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_ME) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SR) == TRUE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_SM) == FALSE);
+  test_result(ATGEN_IsMemoryWriteable(&data, MEM_MT) == TRUE);
+}

--- a/tests/atgen/set-requested-sms-memory.c
+++ b/tests/atgen/set-requested-sms-memory.c
@@ -1,0 +1,217 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+
+void memories_not_enabled(void)
+{
+  GSM_Error error;
+  GSM_MemoryType type;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = { "ERROR\r\n" };
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  type = MEM_ME;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  type = MEM_SM;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  type = MEM_SR;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  type = MEM_MT;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  cleanup_state_machine(s);
+}
+
+void invalid_memory_type(void)
+{
+  GSM_Error error;
+  GSM_MemoryType type = (GSM_MemoryType)0;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = { "ERROR\r\n" };
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  Priv->PhoneSMSMemory = Priv->SRSMSMemory = Priv->SIMSMSMemory = AT_AVAILABLE;
+
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_INVALID_OPERATION);
+
+  type = MEM_INVALID;
+
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_INVALID_OPERATION);
+
+  cleanup_state_machine(s);
+}
+
+void enabled_for_reading(void)
+{
+  GSM_Error error;
+  GSM_MemoryType type;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = { "OK\r\n" };
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  Priv->PhoneSMSMemory = AT_AVAILABLE;
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_ME;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == MEM_ME);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_NONE);
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+  type = MEM_MT;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == MEM_MT);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_NONE);
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_SM;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == 0);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_ME;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == 0);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  cleanup_state_machine(s);
+}
+
+void enabled_for_writing(void)
+{
+  GSM_Error error;
+  GSM_MemoryType type;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = { "OK\r\n" };
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  Priv->PhoneSMSMemory = Priv->SRSMSMemory = Priv->SIMSMSMemory = AT_AVAILABLE;
+  Priv->SRSaveSMS = AT_AVAILABLE;
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_SR;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == MEM_SR);
+  test_result(Priv->SMSMemoryWrite == TRUE);
+  test_result(error == ERR_NONE);
+
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_SM;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == 0);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_MEMORY_NOT_AVAILABLE);
+
+  Priv->SIMSaveSMS = AT_AVAILABLE;
+  Priv->SMSMemory = (GSM_MemoryType)0;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_MT;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == MEM_MT);
+  test_result(Priv->SMSMemoryWrite == TRUE);
+  test_result(error == ERR_NONE);
+
+  cleanup_state_machine(s);
+}
+
+void requested_already_set(void)
+{
+  GSM_Error error;
+  GSM_MemoryType type;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  const char *responses[] = { "ERROR\r\n" };
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  Priv->SIMSMSMemory = Priv->SIMSaveSMS = AT_AVAILABLE;
+  Priv->SRSMSMemory = Priv->SRSaveSMS = AT_AVAILABLE;
+
+  Priv->SMSMemory = MEM_SM;
+  Priv->SMSMemoryWrite = FALSE;
+
+  type = MEM_SM;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, FALSE, ID_SetMemoryType);
+  test_result(  Priv->SMSMemory == MEM_SM);
+  test_result(Priv->SMSMemoryWrite == FALSE);
+  test_result(error == ERR_NONE);
+
+  Priv->SMSMemory = MEM_SR;
+  Priv->SMSMemoryWrite = TRUE;
+
+  type = MEM_SR;
+  SET_RESPONSES(responses);
+  error = ATGEN_SetRequestedSMSMemory(s, type, TRUE, ID_SetMemoryType);
+  test_result(Priv->SMSMemory == MEM_SR);
+  test_result(Priv->SMSMemoryWrite == TRUE);
+  test_result(error == ERR_NONE);
+
+  cleanup_state_machine(s);
+}
+
+int main(void)
+{
+  invalid_memory_type();
+  memories_not_enabled();
+  enabled_for_reading();
+  enabled_for_writing();
+  requested_already_set();
+}

--- a/tests/atgen/test_helper.c
+++ b/tests/atgen/test_helper.c
@@ -1,0 +1,194 @@
+#include <gammu-error.h>
+#include <gammu-statemachine.h>
+#include <gammu-debug.h>
+#include <assert.h>
+#include "../../libgammu/gsmstate.h"
+#include "../../libgammu/gsmphones.h"
+
+#include "test_helper.h"
+
+ssize_t _ResponseReadDevice(GSM_StateMachine *s, void *buf, size_t nbytes);
+GSM_Error _ResponseWriteMessage(GSM_StateMachine *s, unsigned const char *buffer, size_t length, int type);
+
+#define  _BUFFER_SIZE 512
+
+static struct {
+  int echoed;
+  size_t echo_len;
+  unsigned char echo[_BUFFER_SIZE];
+} _echo_buffer;
+
+static struct {
+  GSM_StateMachine *stateMachine;
+  size_t pos;
+  size_t queue_size;
+  const char **queue;
+} _response_queue;
+
+static GSM_Device_Functions _response_dev_funcs;
+
+void bind_response_handling(GSM_StateMachine *s)
+{
+  _response_queue.stateMachine = s;
+  _response_dev_funcs.ReadDevice = &_ResponseReadDevice;
+  memset(&_echo_buffer, 0, sizeof(_echo_buffer));
+
+  if(s->Device.Functions == NULL)
+    s->Device.Functions = &_response_dev_funcs;
+  else
+    s->Device.Functions->ReadDevice = _response_dev_funcs.ReadDevice;
+
+  s->Protocol.Functions = &ATProtocol;
+  s->Protocol.Functions->WriteMessage = &_ResponseWriteMessage;
+  s->ReplyNum = 1;
+  s->opened = TRUE;
+}
+
+void set_responses(const char **responses, size_t size)
+{
+  _response_queue.queue = responses;
+  _response_queue.pos = 0;
+  _response_queue.queue_size = size;
+}
+
+const unsigned char* last_command(void)
+{
+  return _echo_buffer.echo;
+}
+
+void set_echo(const void *buf, const size_t len)
+{
+  if(buf && len > 0) {
+    memccpy(_echo_buffer.echo, buf, sizeof(buf), len);
+    _echo_buffer.echo[len] = '\0';
+    _echo_buffer.echo_len = len;
+    _echo_buffer.echoed = FALSE;
+  }
+}
+
+ssize_t _ResponseReadDevice(GSM_StateMachine *s UNUSED, void *buf, size_t nbytes)
+{
+  size_t read_len = 0;
+
+  if(_response_queue.stateMachine->Phone.Data.SentMsg == NULL)
+    return 0;
+
+  if(_echo_buffer.echoed == FALSE && _echo_buffer.echo_len > 0) {
+    read_len = _echo_buffer.echo_len;
+    if(read_len > nbytes) {
+      // shouldn't happen in current design, so truncate for now.
+      memcpy(buf, _echo_buffer.echo, nbytes);
+    } else {
+      memcpy(buf, _echo_buffer.echo, read_len);
+    }
+
+    _echo_buffer.echoed = TRUE;
+  }
+  else if(_response_queue.pos < _response_queue.queue_size) {
+    read_len = strlen(_response_queue.queue[_response_queue.pos]);
+    if(read_len > nbytes)
+      return 0;
+
+    memcpy(buf, _response_queue.queue[_response_queue.pos], read_len);
+    _response_queue.pos++;
+  }
+
+  return read_len;
+}
+
+GSM_Error _ResponseWriteMessage(GSM_StateMachine *s UNUSED, unsigned const char *buffer, size_t length, int type UNUSED)
+{
+  if(length) {
+    GSM_DumpMessageText(s, buffer, length, type);
+    GSM_DumpMessageBinary(s, buffer, length, type);
+
+    set_echo(buffer, length);
+  }
+  return ERR_NONE;
+}
+
+GSM_StateMachine* setup_state_machine(void)
+{
+  GSM_Debug_Info *debug_info;
+  GSM_StateMachine *s;
+
+  /* Configure state machine */
+  debug_info = GSM_GetGlobalDebug();
+  GSM_SetDebugFileDescriptor(stderr, FALSE, debug_info);
+  GSM_SetDebugLevel("textall", debug_info);
+
+  /* Allocates state machine */
+  s = GSM_AllocStateMachine();
+  test_result(s != NULL);
+  debug_info = GSM_GetDebug(s);
+  GSM_SetDebugGlobal(TRUE, debug_info);
+
+  s->ReplyNum = 1;
+
+  return s;
+}
+
+void cleanup_state_machine(GSM_StateMachine *s)
+{
+  if(s->Phone.Data.Priv.ATGEN.Lines.allocated > 0) {
+    FreeLines(&s->Phone.Data.Priv.ATGEN.Lines);
+    GetLineString(NULL, NULL, 0);
+  }
+
+  GSM_FreeStateMachine(s);
+}
+
+GSM_Phone_ATGENData* setup_at_engine(GSM_StateMachine *s)
+{
+  GSM_Phone_Data *Data;
+  GSM_Phone_ATGENData *Priv;
+  GSM_Protocol_ATData *d;
+
+  /* Initialize AT engine */
+  Data = &s->Phone.Data;
+  Data->ModelInfo = GetModelData(NULL, NULL, "unknown", NULL);
+  Data->RequestID = ID_None;
+
+  Priv = &s->Phone.Data.Priv.ATGEN;
+  Priv->ReplyState = AT_Reply_OK;
+  Priv->SMSMode = SMS_AT_PDU;
+  Priv->Charset = AT_CHARSET_GSM;
+  s->Phone.Functions = &ATGENPhone;
+
+  d = &s->Protocol.Data.AT;
+  d->Msg.Buffer 		= NULL;
+  d->Msg.BufferUsed	= 0;
+  d->Msg.Length		= 0;
+  d->Msg.Type		= 0;
+  d->SpecialAnswerLines	= 0;
+  d->LineStart		= -1;
+  d->LineEnd		= -1;
+  d->wascrlf 		= FALSE;
+  d->EditMode		= FALSE;
+  d->FastWrite		= FALSE;
+  d->CPINNoOK		= FALSE;
+
+  return Priv;
+}
+
+size_t read_file(const char *filepath,void *buffer,  const size_t buffer_len)
+{
+  FILE *f;
+  size_t bytes_read = 0;
+
+  assert(NULL != buffer);
+
+  f = fopen(filepath, "r");
+  if (f == NULL) {
+    printf("Could not open %s\n", filepath);
+    return 0;
+  }
+
+  bytes_read = fread(buffer, 1, buffer_len, f);
+
+  if (!feof(f))
+    printf("Could not read whole file %s\n", filepath);
+
+  fclose(f);
+  return bytes_read;
+}

--- a/tests/atgen/test_helper.h
+++ b/tests/atgen/test_helper.h
@@ -1,0 +1,22 @@
+#ifndef H_ATGEN_TEST_HELPER_INCLUDED
+#define H_ATGEN_TEST_HELPER_INCLUDED
+
+#include <stdlib.h>
+#include "../../libgammu/phone/at/atgen.h"
+#include "../common.h"
+
+#define SET_RESPONSES(responses) \
+  set_responses(responses, sizeof(responses) / sizeof(*(responses)))
+
+GSM_StateMachine* setup_state_machine(void);
+GSM_Phone_ATGENData* setup_at_engine(GSM_StateMachine *s);
+void cleanup_state_machine(GSM_StateMachine *s);
+
+
+void set_responses(const char **responses, size_t size);
+void bind_response_handling(GSM_StateMachine *s);
+const unsigned char* last_command(void);
+
+size_t read_file(const char *filepath, void *buffer,size_t buffer_len);
+
+#endif /* H_ATGEN_TEST_HELPER_INCLUDED */

--- a/tests/atgen/test_helper.h
+++ b/tests/atgen/test_helper.h
@@ -6,6 +6,10 @@
 #include "../../libgammu/phone/at/atgen.h"
 #include "../common.h"
 
+#if _MSC_VER < 1910
+#define __func__ __FUNCTION__
+#endif
+
 #define UNNEEDED(x) (void)(x)
 
 #define SET_RESPONSES(responses) \

--- a/tests/atgen/test_helper.h
+++ b/tests/atgen/test_helper.h
@@ -5,6 +5,8 @@
 #include "../../libgammu/phone/at/atgen.h"
 #include "../common.h"
 
+#define UNNEEDED(x) (void)(x)
+
 #define SET_RESPONSES(responses) \
   set_responses(responses, sizeof(responses) / sizeof(*(responses)))
 

--- a/tests/atgen/test_helper.h
+++ b/tests/atgen/test_helper.h
@@ -2,6 +2,7 @@
 #define H_ATGEN_TEST_HELPER_INCLUDED
 
 #include <stdlib.h>
+#include <string.h>
 #include "../../libgammu/phone/at/atgen.h"
 #include "../common.h"
 


### PR DESCRIPTION
Enable detection and configuration of SR memory

The underlying codebase is heavily bias toward only supporting SM and ME memory, to limit impact and scope of changes implementation of access to SR memory is limited to that needed to succesfully process +CDSI messages.

To disable on modems with broken SR memory implementation set the `F_SMS_NO_SR` feature flag.

[SMSD] process status reports from SR memory via +CDSI messages

SMSD uses polling to read messages from the terminal device, however processing +CDSI messages is event based. In order to avoid conflict only status reports in SR memory are processed.
