### PR TITLE
initial support for processing +CDS events

### DIFF
--- a/docs/manual/config/index.rst
+++ b/docs/manual/config/index.rst
@@ -317,6 +317,28 @@ Locales and character set options
     ``LANG/LC_MESSAGES/gammu.mo``). If gammu is properly installed it should find
     these files automatically.
 
+Advanced options
+++++++++++++++++
+
+Advanced options are used to alter default logic, when using these options the
+user is responsible for ensuring any settings are correct for the target device
+and that they produce the desired behaviour.
+
+.. config:option:: atgen_setCNMI
+
+    For configurations using the generic AT command protocol it is possible to
+    override the default indicators used when a new SMS message is received.
+
+    The value for the setting is a comma delimited list of single digits
+    corresponding to the values for the ``AT+CNMI`` modem command. If a digit
+    is not provided, or if the provided digit is outside of the acceptable
+    range for the device the default value is used.
+
+    For example setting ``atgen_setcnmi = ,,2`` would set the third parameter of
+    the CNMI command to the value 2, leaving the rest of the parameters at
+    default, and ``atgen_setcnmi = 1,,,1`` would set the first and fourth parameters
+    respectively.
+
 Other options
 +++++++++++++
 

--- a/include/gammu-statemachine.h
+++ b/include/gammu-statemachine.h
@@ -107,6 +107,11 @@ typedef struct {
 	 * Phone features override.
 	 */
 	GSM_Feature PhoneFeatures[GSM_MAX_PHONE_FEATURES + 1];
+	/**
+	 * Used to override default CNMI arguments for generic
+	 * AT protocol.
+	 */
+	 int CNMIParams[4];
 } GSM_Config;
 
 /**

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -2019,24 +2019,26 @@ void SMSD_IncomingUSSDCallback(GSM_StateMachine *sm UNUSED, GSM_USSDMessage *uss
 
 #define INIT_SMSINFO_CACHE_SIZE 10
 /**
- * Called when a +CDSI or +CMTI event is received.
+ * Handles SMS information messages (+CDSI/+CMTI)
  *
  * SMSD uses polling to read messages from MT memory, to avoid potential
- * conflicts only information on status reports stored in SR memory is cached.
+ * conflicts only information on status reports stored in SR memory are handled.
  *
  * The amount of SR memory on a device is generally very small so it's unlikely
  * there would be an issue creating/reallocating the cache, if such an issue
  * occurs some or all status report information records will be lost.
  */
-void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *user_data)
+void SMSD_IncomingSMSInfoCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *user_data)
 {
   GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
   GSM_AT_SMSInfo_Cache *Cache = &Priv->SMSInfoCache;
   GSM_SMSDConfig *Config = user_data;
   void *reallocated = NULL;
 
-  if (sms->PDU != SMS_Status_Report || sms->Memory != MEM_SR)
-    return;
+  if (sms->PDU != SMS_Status_Report || sms->Memory != MEM_SR) {
+  	SMSD_Log(DEBUG_INFO, Config, "Ignoring incoming SMS info as not a Status Report in SR memory.");
+		return;
+	}
 
   SMSD_Log(DEBUG_INFO, Config, "caching incoming status report information.");
 
@@ -2061,6 +2063,33 @@ void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *u
 
   memcpy(Cache->smsInfo_records + Cache->cache_used, sms, sizeof(*Cache->smsInfo_records));
   Cache->cache_used += 1;
+}
+
+/**
+ * Handles incoming SMS messages.
+ *
+ */
+void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *user_data)
+{
+	GSM_MultiSMSMessage msms;
+	GSM_SMSDConfig *Config = user_data;
+	GSM_Error error;
+
+	if(sms->PDU == 0) {
+		// assume we only have message information, not a full message, handoff to appropriate handler
+		SMSD_IncomingSMSInfoCallback(s, sms, user_data);
+		return;
+	}
+
+	SMSD_Log(DEBUG_INFO, Config, "processing incoming SMS.");
+
+	memset(&msms, 0, sizeof(GSM_MultiSMSMessage));
+	msms.Number = 1;
+	msms.SMS[0] = *sms;
+
+	error = SMSD_ProcessSMS(Config, &msms);
+	if(error != ERR_NONE)
+		SMSD_LogError(DEBUG_ERROR, Config, "Error processing SMS", error);
 }
 
 GSM_Error SMSD_ProcessSMSInfoCache(GSM_SMSDConfig *Config)
@@ -2107,7 +2136,7 @@ GSM_Error SMSD_ProcessSMSInfoCache(GSM_SMSDConfig *Config)
 		sms->Memory = MEM_INVALID;
 	}
 
-	/* cache processed successfully, reset used count to reuse cache memory */
+	/* cache processed successfully, reset used count */
 	if(error == ERR_NONE)
 		Cache->cache_used = 0;
 

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -27,6 +27,10 @@ atgen_test(is-memory-enabled)
 atgen_test(is-memory-writeable)
 atgen_test(set-requested-sms-memory)
 atgen_test(incoming-sms-info)
+atgen_test(incoming-sms)
 
+atgen_test(gsm-set-cnmi-params)
 atgen_test(get-sms-location)
 atgen_test(get-sms)
+
+smsd_test(smsd-incoming-cds)

--- a/tests/atgen/gsm-set-cnmi-params.c
+++ b/tests/atgen/gsm-set-cnmi-params.c
@@ -1,0 +1,95 @@
+#include "test_helper.h"
+
+GSM_Error GSM_ReadCNMIParams(int *out_params, const char *args);
+
+int params_eq(const int *a, const int *b) {
+  return memcmp(a, b, 4 * sizeof(int)) == 0;
+}
+
+void with_null_args_does_nothing(void)
+{
+  GSM_Error error;
+  int params[4] = {5,5,5,5};
+  const int expected[4] = {5,5,5,5};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, NULL);
+  test_result(error == ERR_NONE);
+  test_result(params_eq(params, expected));
+}
+
+void with_empty_args_does_nothing(void)
+{
+  GSM_Error error;
+  int params[4] = {5,5,5,5};
+  const int expected[4] = {5,5,5,5};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, "");
+  test_result(error == ERR_NONE);
+  test_result(params_eq(params, expected));
+}
+
+void with_partial_args_defaults_others(void)
+{
+  GSM_Error error;
+  int params[4] = {5,5,5,5};
+  const int expected[4] = {5,5,2,5};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, ",,2");
+  test_result(error == ERR_NONE);
+  test_result(params_eq(params, expected));
+}
+
+void ignores_spaces(void)
+{
+  GSM_Error error;
+  int params[4] = {5,5,5,5};
+  const int expected[4] = {1,5,7,5};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, "  1 , ,7, ");
+  test_result(error == ERR_NONE);
+  test_result(params_eq(params, expected));
+}
+
+void sets_all_params(void)
+{
+  GSM_Error error;
+  int params[4] = {0};
+  const int expected[4] = {1,2,3,4};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, "1,2,3,4");
+  test_result(error == ERR_NONE);
+  test_result(params_eq(params, expected));
+}
+
+void fails_on_invalid_input(void)
+{
+  GSM_Error error;
+  int params[4] = {0};
+  const int expected[4] = {1,2};
+
+  puts(__func__);
+
+  error = GSM_ReadCNMIParams(params, "\t1, 2;3,4");
+  test_result(error == ERR_INVALIDDATA);
+  test_result(params_eq(params, expected));
+}
+
+int main(void)
+{
+  with_null_args_does_nothing();
+  with_empty_args_does_nothing();
+  with_partial_args_defaults_others();
+  ignores_spaces();
+  sets_all_params();
+  fails_on_invalid_input();
+}

--- a/tests/atgen/incoming-sms-info.c
+++ b/tests/atgen/incoming-sms-info.c
@@ -90,6 +90,36 @@ void ignore_if_no_handler(void)
   cleanup_state_machine(s);
 }
 
+void ignore_if_no_cmti_handler(void)
+{
+  GSM_Error error;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_Message msg;
+
+  const char *event = "+CMTI: \"SR\",0\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  UNNEEDED(Priv);
+
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+
+  msg.Length = strlen(event);
+  msg.Buffer = (char*)event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+
+  cleanup_state_machine(s);
+}
+
 void skip_if_memory_disabled(void)
 {
   GSM_Error error;
@@ -177,7 +207,7 @@ void cmti_sm_1(void)
   GSM_Phone_ATGENData *Priv = setup_at_engine(s);
   GSM_Protocol_Message msg;
 
-  const char *event = "+CDSI: \"SM\",1\r\n";
+  const char *event = "+CMTI: \"SM\",1\r\n";
 
   const char *responses[] = {
       "+CPMS: (\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"MT\",\"SM\",\"SR\"),(\"ME\",\"SM\")\r",
@@ -218,6 +248,7 @@ int main(void)
 {
   ignore_if_incoming_sms_disabled();
   ignore_if_no_handler();
+  ignore_if_no_cmti_handler();
   skip_if_memory_disabled();
   cdsi_sr_0();
   cmti_sm_1();

--- a/tests/atgen/incoming-sms.c
+++ b/tests/atgen/incoming-sms.c
@@ -1,0 +1,127 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+#include "../../libgammu/phone/at/atgen.h"
+#include "../../libgammu/gsmstate.h"
+
+int is_empty(const char *buffer, size_t length)
+{
+  if(buffer != NULL && length > 0)
+    for(size_t i = 0; i < length; ++i)
+      if(buffer[i] != '\0') return FALSE;
+
+  return TRUE;
+}
+
+void IncomingSMS(GSM_StateMachine * s, GSM_SMSMessage *sms, void *user_data)
+{
+  if(user_data != NULL)
+    memcpy(user_data, sms, sizeof(GSM_SMSMessage));
+}
+
+void ignore_if_incoming_sms_disabled(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_Message msg;
+
+  const char *event = "+CDS:25\rBAD\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  UNNEEDED(Priv);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = FALSE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = (char*)event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(is_empty((char*)&sms, sizeof(sms)));
+
+  cleanup_state_machine(s);
+}
+
+void ignore_if_no_cds_handler(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_Message msg;
+
+  const char *event = "+CDS:25\rBAD\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  UNNEEDED(Priv);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+
+  msg.Length = strlen(event);
+  msg.Buffer = (char*)event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(is_empty((char*)&sms, sizeof(sms)));
+
+  cleanup_state_machine(s);
+}
+
+void process_cds(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_Protocol_Message msg;
+
+  const char *event = "+CDS:25\r07914875215652F006360B914892347527F3817003018104808170030181448000\r";
+  const char *responses[] = { "ERROR\r\n" };
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  puts(__func__);
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &IncomingSMS;
+  s->User.IncomingSMSUserData = &sms;
+
+  msg.Length = strlen(event);
+  msg.Buffer = (char*)event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(sms.PDU == SMS_Status_Report);
+
+  cleanup_state_machine(s);
+}
+
+int main(void)
+{
+  ignore_if_incoming_sms_disabled();
+  ignore_if_no_cds_handler();
+  process_cds();
+}

--- a/tests/atgen/incoming-sms.c
+++ b/tests/atgen/incoming-sms.c
@@ -3,11 +3,14 @@
 #include "../../libgammu/phone/at/atgen.h"
 #include "../../libgammu/gsmstate.h"
 
-int is_empty(const char *buffer, size_t length)
+int is_empty(const char *buffer, const int length)
 {
+  int i;
+
   if(buffer != NULL && length > 0)
-    for(size_t i = 0; i < length; ++i)
-      if(buffer[i] != '\0') return FALSE;
+    for(i = 0; i < length; ++i)
+      if(buffer[i] != '\0')
+        return FALSE;
 
   return TRUE;
 }

--- a/tests/atgen/incoming-sms.c
+++ b/tests/atgen/incoming-sms.c
@@ -101,6 +101,8 @@ void process_cds(void)
 
   puts(__func__);
 
+  UNNEEDED(Priv);
+
   memset(&sms, 0, sizeof(sms));
   s->Phone.Data.EnableIncomingSMS = TRUE;
   s->Phone.Data.RequestID = ID_None;

--- a/tests/atgen/smsd-incoming-cds.c
+++ b/tests/atgen/smsd-incoming-cds.c
@@ -1,0 +1,59 @@
+#include <gammu-message.h>
+#include "test_helper.h"
+#include "../../include/gammu-smsd.h"
+#include "../../smsd/core.h"
+#include "../../libgammu/gsmstate.h"
+#include "../../smsd/services/files.h"
+
+GSM_Error SMSD_ConfigureLogging(GSM_SMSDConfig *Config, gboolean uselog);
+void SMSD_IncomingSMSCallback(GSM_StateMachine *s,  GSM_SMSMessage *sms, void *user_data);
+
+int main(void)
+{
+  GSM_Error error;
+  GSM_SMSMessage sms;
+  GSM_StateMachine *s = setup_state_machine();
+  GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+  GSM_SMSDStatus status;
+  GSM_SMSDConfig *config = SMSD_NewConfig("test");
+  GSM_Protocol_Message msg;
+  const char *event = "+CDS:25\r07914875215652F006360B914892347527F3817003018104808170030181448000\r";
+  const char *responses[] = { "ERROR\r\n" };
+
+  UNNEEDED(Priv);
+
+  SET_RESPONSES(responses);
+  bind_response_handling(s);
+
+  config->debug_level = 255;
+  config->logfilename = "stderr";
+  config->gsm = s;
+  config->loopsleep = 8;
+  config->deliveryreport = "sms";
+  config->gsm->opened = TRUE;
+  SMSD_ConfigureLogging(config, TRUE);
+
+  config->Service = &SMSDFiles;
+  config->Service->ReadConfiguration(config);
+  config->Service->Init(config);
+
+  memset(&status, 0, sizeof(GSM_SMSDStatus));
+  config->Status = &status;
+
+  memset(&sms, 0, sizeof(sms));
+  s->Phone.Data.EnableIncomingSMS = TRUE;
+  s->Phone.Data.RequestID = ID_None;
+  s->User.IncomingSMS = &SMSD_IncomingSMSCallback;
+  s->User.IncomingSMSUserData = config;
+
+  msg.Length = strlen(event);
+  msg.Buffer = (char*)event;
+  msg.Type = 0;
+
+  s->Phone.Data.RequestMsg = &msg;
+  error = ATGEN_DispatchMessage(s);
+  test_result(error == ERR_NONE);
+  test_result(status.Received == 1);
+
+  SMSD_FreeConfig(config);
+}

--- a/tests/config.c
+++ b/tests/config.c
@@ -11,7 +11,7 @@
 int main(int argc, char **argv)
 {
 	GSM_Error error;
-	GSM_Config cfg = { "", "", NULL, NULL, FALSE, FALSE, NULL, FALSE, FALSE, "", "", "", "", "", {0} };
+	GSM_Config cfg = { "", "", NULL, NULL, FALSE, FALSE, NULL, FALSE, FALSE, "", "", "", "", "", {0}, {0} };
 	INI_Section *ini = NULL;
 
 	/* Check parameters */


### PR DESCRIPTION
Provides the ability for users to configure CNMI parameters so they may request to receive SR reports via +CDS notifications, and provides a handler for processing SR reports via +CDS.

Usually in order to receives SR messages via +CDS events CNMI mode needs to be set to 1, this will likely result in discarded messages when TA-TE link is up.

may address issue  #272