### PR TITLE
Guard against exceeding GSM_MAX_MULTI_SMS in function GSM_LinkSMS

### DIFF
--- a/libgammu/service/sms/gsmmulti.c
+++ b/libgammu/service/sms/gsmmulti.c
@@ -1562,6 +1562,14 @@ GSM_Error GSM_LinkSMS(GSM_Debug_Info *di, GSM_MultiSMSMessage **InputMessages, G
 			j		= 1;
 			/* We're searching for other parts in sequence */
 			while (j!=(int)SiemensOTA.PacketsNum) {
+
+        if(j >= GSM_MAX_MULTI_SMS) {
+          smfprintf(di,
+            "WARNING: Hard coded message parts limit of %d has been reached,"
+						"skipping remaining parts.\n", GSM_MAX_MULTI_SMS);
+          break;
+        }
+
 				z=0;
 				while(InputMessages[z]!=NULL) {
 					/* This was sorted earlier or is not single */
@@ -1742,6 +1750,14 @@ GSM_Error GSM_LinkSMS(GSM_Debug_Info *di, GSM_MultiSMSMessage **InputMessages, G
 			j		= 1;
 			/* We're searching for other parts in sequence */
 			while (j != InputMessages[i]->SMS[0].UDH.AllParts) {
+
+				if(j >= GSM_MAX_MULTI_SMS) {
+					smfprintf(di,
+						"WARNING: Hard coded message parts limit of %d has been reached,"
+			      "skipping remaining parts.\n", GSM_MAX_MULTI_SMS);
+					break;
+				}
+
 				z=0;
 				while(InputMessages[z]!=NULL) {
 					/* This was sorted earlier or is not single */


### PR DESCRIPTION
Prevents heap corruption when the number of message parts of a
multipart message exceeds GSM_MAX_MULTI_SMS.

Fixes #442 


@nijel, currently the *gammu* codebase has a mixture of tabs and spaces for indentation, sometimes mixed in the same file. As there's not a lot of code commits at the moment would you mind if I did a single codebase reformat commit, ensuring all tabs are changed to spaces? My own preference is 2 spaces for indentation but will go with whatever you prefer, thanks.