### PR TITLE
Increased capacity of NetworkInfo.NetworkName buffer

### DIFF
--- a/include/gammu-info.h
+++ b/include/gammu-info.h
@@ -130,9 +130,11 @@ typedef struct {
 	 */
 	char LAC[10];
 	/**
-	 * Name of current network like returned from phone (or empty).
+	 * Name of current network returned from phone (or empty).
+	 * The buffer needs to have twice the capacity of the longest supported
+	 * network name to account for decoding.
 	 */
-	unsigned char NetworkName[15 * 2];
+	unsigned char NetworkName[20 * 2];
 	/**
 	 * GPRS state.
 	 */

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -3209,6 +3209,7 @@ GSM_Error ATGEN_ReplyGetNetworkName(GSM_Protocol_Message *msg, GSM_StateMachine 
 
 		/* Cleanup if something went wrong */
 		if (error != ERR_NONE) {
+		  smprintf(s, "WARNING: Failed to store network name - ERROR(%s)", GSM_ErrorName(error));
 			NetworkInfo->NetworkName[0] = 0;
 			NetworkInfo->NetworkName[1] = 0;
 		}


### PR DESCRIPTION
The previous limit of 30 bytes was not sufficient to decode longer
network names, limit has been increased to 40 bytes.

Also a debug warning will be issued if the network name cannot be
stored.

Fixes #415