### PR TITLE
fix timestamp conversions

### DIFF
--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -1781,7 +1781,7 @@ time_t SMSDSQL_ParseDate(GSM_SMSDConfig * Config, const char *date)
 		return -2;
 	}
 
-	parse_res = strptime(date, "%Y-%m-%d %T", &tm);
+	parse_res = strptime(date, "%Y-%m-%d %H:%M:%S", &tm);
 	if (parse_res != NULL && *parse_res == 0) {
 	  tm.tm_isdst = -1;
 	  time = mktime(&tm);

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -282,34 +282,54 @@ static GSM_Error SMSDSQL_Query(GSM_SMSDConfig * Config, const char *query, SQL_r
 	return error;
 }
 
+/*
+ * generates a timestamp string suitable for inserting into a database, the timestamp
+ * argument must be a valid POSIX calendar time.
+ *
+ * pgsql: https://www.postgresql.org/docs/9.1/datatype-datetime.html
+ *   - "For timestamp with time zone, the internally stored value is always in UTC
+ *      (Universal Coordinated Time, traditionally known as Greenwich Mean Time, GMT).
+ *      An input value that has an explicit time zone specified is converted to UTC
+ *      using the appropriate offset for that time zone.
+ *
+ *      If no time zone is stated in the input string, then it is assumed to be in the
+ *      time zone indicated by the system's timezone parameter, and is converted to
+ *      UTC using the offset for the timezone zone. When a timestamp with time zone
+ *      value is output, it is always converted from UTC to the current timezone zone,
+ *      and displayed as local time in that zone. To see the time in another time zone,
+ *      either change timezone or use the AT TIME ZONE construct (see Section 9.9.3).
+ *
+ *      Conversions between timestamp without time zone and timestamp with time zone
+ *      normally assume that the timestamp without time zone value should be taken or
+ *      given as timezone local time."
+ *
+ * mysql: https://dev.mysql.com/doc/refman/8.0/en/datetime.html
+ *  - "MySQL converts TIMESTAMP values from the current time zone to UTC for
+ *     storage, and back from UTC to the current time zone for retrieval."
+ *
+ * oracle: https://docs.oracle.com/cd/B19306_01/server.102/b14225/ch4datetime.htm#i1006050
+ *  - a TIMESTAMP literal without tz info is interpreted as local time zone.
+ */
 void SMSDSQL_Time2String(GSM_SMSDConfig * Config, time_t timestamp, char *static_buff, size_t size)
 {
-	struct tm *timestruct;
-	const char *driver_name;
+	const char *driver_name = SMSDSQL_SQLName(Config);
+	struct tm *tm = localtime(&timestamp);
 
-	driver_name = SMSDSQL_SQLName(Config);
-
-	if (timestamp == -2) {
-		strcpy(static_buff, "0000-00-00 00:00:00");
-	} else if (strcasecmp(driver_name, "pgsql") == 0 || strcasecmp(driver_name, "native_pgsql") == 0) {
-		timestruct = localtime(&timestamp);
-		strftime(static_buff, size, "%Y-%m-%d %H:%M:%S GMT", timestruct);
-	} else if (strcasecmp(driver_name, "access") == 0) {
-		timestruct = gmtime(&timestamp);
-		strftime(static_buff, size, "'%Y-%m-%d %H:%M:%S'", timestruct);
-	} else if (strcasecmp(driver_name, "mysql") == 0 || strcasecmp(driver_name, "native_mysql") == 0) {
-		timestruct = localtime(&timestamp);
-		strftime(static_buff, size, "%Y-%m-%d %H:%M:%S", timestruct);
-	} else if (strcasecmp(driver_name, "oracle") == 0) {
-		timestruct = gmtime(&timestamp);
-		strftime(static_buff, size, "TIMESTAMP '%Y-%m-%d %H:%M:%S +00:00'", timestruct);
-	} else if (strcasecmp(Config->driver, "odbc") == 0) {
-		timestruct = gmtime(&timestamp);
-		strftime(static_buff, size, "{ ts '%Y-%m-%d %H:%M:%S' }", timestruct);
-	} else {
-		timestruct = localtime(&timestamp);
-		strftime(static_buff, size, "%Y-%m-%d %H:%M:%S", timestruct);
-	}
+  if(timestamp == -2) {
+    strcpy(static_buff, "0000-00-00 00:00:00");
+  }
+  else if (strcasecmp(driver_name, "oracle") == 0) {
+    strftime(static_buff, size, "TIMESTAMP '%Y-%m-%d %H:%M:%S'", tm);
+  }
+  else if (strcasecmp(Config->driver, "odbc") == 0) {
+    strftime(static_buff, size, "{ ts '%Y-%m-%d %H:%M:%S' }", tm);
+  }
+  else if (strcasecmp(driver_name, "access") == 0) {
+    strftime(static_buff, size, "'%Y-%m-%d %H:%M:%S'", tm);
+  }
+  else {
+    strftime(static_buff, size, "%Y-%m-%d %H:%M:%S", tm);
+  }
 }
 
 static GSM_Error SMSDSQL_NamedQuery(GSM_SMSDConfig * Config, const char *sql_query, GSM_SMSMessage *sms,
@@ -1743,33 +1763,35 @@ GSM_Error SMSDSQL_ReadConfiguration(GSM_SMSDConfig *Config)
 	return ERR_NONE;
 }
 
+/* Converts the given local date and time into POSIX calendar time
+ *
+ * The date string argument must be a system local point in time
+ * formatted as "YYYY-MM-DD HH:MM:SS"
+ *
+ * returns the POSIX (UTC) calendar time for the given date/time, or
+ * a negative time_t on error.
+ */
 time_t SMSDSQL_ParseDate(GSM_SMSDConfig * Config, const char *date)
 {
 	char *parse_res;
-	struct tm timestruct;
-	GSM_DateTime DT;
+	struct tm tm;
+	time_t time = -1;
 
 	if (strcmp(date, "0000-00-00 00:00:00") == 0) {
 		return -2;
 	}
 
-	parse_res = strptime(date, "%Y-%m-%d %H:%M:%S", &timestruct);
-
+	parse_res = strptime(date, "%Y-%m-%d %T", &tm);
 	if (parse_res != NULL && *parse_res == 0) {
-		DT.Year = timestruct.tm_year + 1900;
-		DT.Month = timestruct.tm_mon + 1;
-		DT.Day = timestruct.tm_mday;
-		DT.Hour = timestruct.tm_hour;
-		DT.Minute = timestruct.tm_min;
-		DT.Second = timestruct.tm_sec;
-
-		return Fill_Time_T(DT);
+	  tm.tm_isdst = -1;
+	  time = mktime(&tm);
 	}
-	/* Used during testing */
-	if (Config != NULL) {
+	else if (Config != NULL) {
+    /* Used during testing */
 		SMSD_Log(DEBUG_ERROR, Config, "Failed to parse date: %s", date);
 	}
-	return -1;
+
+	return time;
 }
 
 GSM_SMSDService SMSDSQL = {

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -42,6 +42,6 @@ atgen_test(gsm-set-cnmi-params)
 atgen_test(get-sms-location)
 atgen_test(get-sms)
 
+smsd_test(test_sql_time)
 smsd_test(smsd-incoming-cds)
 smsd_test(smsd-incoming-ussd)
-

--- a/tests/atgen/test_sql_time.c
+++ b/tests/atgen/test_sql_time.c
@@ -1,0 +1,336 @@
+#include "test_helper.h"
+#include "../../smsd/core.h"
+
+#define TS20190715120000 1563192000
+#define TS20191215120000 1576411200
+
+void SMSDSQL_Time2String(GSM_SMSDConfig * Config, time_t timestamp, char *static_buff, size_t size);
+time_t SMSDSQL_ParseDate(GSM_SMSDConfig * Config, const char *date);
+
+int get_local_timezone_offset(time_t posix_time);
+
+void print_time(const struct tm *tm)
+{
+  char buffer[128];
+  strftime(buffer, 128, "'%Y-%m-%d %H:%M:%S'", tm);
+  puts(buffer);
+}
+
+GSM_DateTime *mk_dt(
+  int year, int month, int day,
+  int hour, int minute, int second,
+  int offset)
+{
+  static GSM_DateTime dt;
+
+  dt.Year = year;
+  dt.Month = month;
+  dt.Day = day;
+  dt.Hour = hour;
+  dt.Minute = minute;
+  dt.Second = second;
+  dt.Timezone = offset*3600;
+
+  return &dt;
+}
+
+void get_sql_string(char *dest, const char* driver_name, time_t posix_time)
+{
+  GSM_SMSDConfig config;
+  memset(&config, 0, sizeof(GSM_SMSDConfig));
+  config.driver = driver_name;
+  SMSDSQL_Time2String(&config, posix_time, dest, 128);
+}
+
+/**************************************************/
+
+void test_fill_time_t_gmt(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 12, 15, 12, 00, 00, 0);
+  struct tm tm;
+  time_t time;
+
+  puts(__func__);
+
+  time = Fill_Time_T(dt);
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/London");
+#else
+  putenv("TZ=GMT0");
+  tzset();
+#endif
+  tm = *localtime(&time);
+
+  test_result(tm.tm_hour == 12);
+  test_result(time == TS20191215120000);
+}
+
+void test_fill_time_t_dst(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 7, 15, 12, 00, 00, 0);
+  struct tm tm;
+  time_t time;
+
+  puts(__func__);
+
+  time = Fill_Time_T(dt);
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/London");
+#else
+  putenv("TZ=GMT-1");
+  tzset();
+#endif
+  tm = *localtime(&time);
+
+  test_result(tm.tm_hour == 13);
+  test_result(time == TS20190715120000);
+}
+
+void test_fill_time_t_cet(void)
+{
+  // origin timestamp +5 hours == GMT0700 == CET0800
+  GSM_DateTime dt = *mk_dt(2019, 12, 15, 12, 00, 00, 5);
+  struct tm tm;
+  time_t time;
+
+  puts(__func__);
+
+  time = Fill_Time_T(dt);
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-1");
+  tzset();
+#endif
+  tm = *localtime(&time);
+
+  test_result(tm.tm_hour == 8);
+  test_result(time == TS20191215120000 - 5*3600);
+}
+
+void test_fill_time_t_cest(void)
+{
+  // origin timestamp -3 hours == GMT1500 == CEST1700
+  GSM_DateTime dt = *mk_dt(2019, 7, 15, 12, 00, 00, -3);
+  struct tm tm;
+  time_t time;
+
+  puts(__func__);
+
+  time = Fill_Time_T(dt);
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  tm = *localtime(&time);
+
+  test_result(tm.tm_hour == 17);
+  test_result(time == TS20190715120000 + 3*3600);
+}
+
+void test_local_tz_offset_cet(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 12, 15, 12, 00, 00, 0);
+  int offset;
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-1");
+  tzset();
+#endif
+
+  offset = get_local_timezone_offset(Fill_Time_T(dt));
+  test_result(offset == 3600);
+}
+
+void test_local_tz_offset_cest(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 7, 15, 12, 00, 00, 0);
+  int offset;
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char *) "TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+
+  offset = get_local_timezone_offset(Fill_Time_T(dt));
+  test_result(offset == 7200);
+}
+
+void test_sql_parse_date_no_dst(void)
+{
+  const char* expected = "2019-12-15 12:00:00";
+  char actual[128];
+  time_t time;
+  struct tm tm;
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-1");
+  tzset();
+#endif
+  time = SMSDSQL_ParseDate(NULL, expected);
+  tm = *localtime(&time);
+
+  strftime(actual, 128, "%Y-%m-%d %T", &tm);
+  test_result(strcmp(expected, actual) == 0);
+}
+
+void test_sql_parse_date_with_dst(void)
+{
+  const char* expected = "2019-07-15 12:00:00";
+  char actual[128];
+  time_t time;
+  struct tm tm;
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  time = SMSDSQL_ParseDate(NULL, expected);
+  tm = *localtime(&time);
+
+  strftime(actual, 128, "%Y-%m-%d %T", &tm);
+  test_result(strcmp(expected, actual) == 0);
+}
+
+void neg_timestamp(void)
+{
+  char actual[128];
+
+  puts(__func__);
+
+  get_sql_string(actual, "pgsql", -2);
+
+  test_result(strcmp("0000-00-00 00:00:00", actual) == 0);
+}
+
+void pgsql_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, 2);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  get_sql_string(actual, "pgsql", Fill_Time_T(dt));
+
+  test_result(strcmp("2019-05-08 11:48:44", actual) == 0);
+}
+
+void mysql_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, 0);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  get_sql_string(actual, "mysql", Fill_Time_T(dt));
+
+  test_result(strcmp("2019-05-08 13:48:44", actual) == 0);
+}
+
+void oracle_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, -3);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/London");
+#else
+  putenv("TZ=GMT-1");
+  tzset();
+#endif
+  get_sql_string(actual, "oracle", Fill_Time_T(dt));
+
+  test_result(strcmp("TIMESTAMP '2019-05-08 15:48:44'", actual) == 0);
+}
+
+void odbc_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 12, 8, 11, 48, 44, 0);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/London");
+#else
+  putenv("TZ=GMT0");
+  tzset();
+#endif
+  get_sql_string(actual, "odbc", Fill_Time_T(dt));
+
+  test_result(strcmp("{ ts '2019-12-08 11:48:44' }", actual) == 0);
+}
+
+void access_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, 0);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  get_sql_string(actual, "access", Fill_Time_T(dt));
+
+  test_result(strcmp("'2019-05-08 13:48:44'", actual) == 0);
+}
+
+int main(void)
+{
+  test_fill_time_t_gmt();
+  test_fill_time_t_dst();
+
+  test_fill_time_t_cet();
+  test_fill_time_t_cest();
+
+  test_local_tz_offset_cet();
+  test_local_tz_offset_cest();
+
+  test_sql_parse_date_no_dst();
+  test_sql_parse_date_with_dst();
+
+  neg_timestamp();
+
+  pgsql_timestamp();
+  mysql_timestamp();
+  oracle_timestamp();
+
+  odbc_timestamp();
+  access_timestamp();
+}

--- a/tests/atgen/test_sql_time.c
+++ b/tests/atgen/test_sql_time.c
@@ -11,7 +11,7 @@ int get_local_timezone_offset(time_t posix_time);
 
 void print_time(const struct tm *tm)
 {
-  char buffer[128];
+	char buffer[128] = {0};
   strftime(buffer, 128, "'%Y-%m-%d %H:%M:%S'", tm);
   puts(buffer);
 }
@@ -184,7 +184,7 @@ void test_sql_parse_date_no_dst(void)
   time = SMSDSQL_ParseDate(NULL, expected);
   tm = *localtime(&time);
 
-  strftime(actual, 128, "%Y-%m-%d %T", &tm);
+  strftime(actual, 128, "%Y-%m-%d %H:%M:%S", &tm);
   test_result(strcmp(expected, actual) == 0);
 }
 
@@ -206,7 +206,7 @@ void test_sql_parse_date_with_dst(void)
   time = SMSDSQL_ParseDate(NULL, expected);
   tm = *localtime(&time);
 
-  strftime(actual, 128, "%Y-%m-%d %T", &tm);
+  strftime(actual, 128, "%Y-%m-%d %H:%M:%S", &tm);
   test_result(strcmp(expected, actual) == 0);
 }
 


### PR DESCRIPTION
This PR corrects a number of time conversion issues and inconsistencies, it allows for consistently creating correct time stamps for inserting into databases regardless of the SMS bearer timezone offset.

It has been tested with Postgres, the time stamp strings for MySQL and Oracle are being generated according to their respective documentation, references are in the function comment of SMSDSQL_Time2String.

Fixes #447