### PR TITLE
Fix off-by-one error in Python script for smsd

### DIFF
--- a/contrib/smsd-scripts/receive-python
+++ b/contrib/smsd-scripts/receive-python
@@ -11,7 +11,7 @@ if numparts == 0:
     text = os.environ['SMS_1_TEXT']
 # Get all text parts
 else:
-    for i in range(0, numparts):
+    for i in range(1, numparts + 1):
         varname = 'DECODED_%d_TEXT' % i
         if varname in os.environ:
             text = text + os.environ[varname]


### PR DESCRIPTION
As far as I can tell, the `DECODED_n_TEXT` variables are numbered from 1, not from 0.

Cc: @hryamzik (who changed this line as part of #287)