### PR TITLE
Init scripts contain the correct install path

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 project (Gammu-contrib C)
 
+include("GNUInstallDirs")
+
 option(INSTALL_GNAPPLET "Install Gnapplet binaries" ON)
 option(INSTALL_S60 "Install Series 60 applet binaries" ON)
 option(INSTALL_MEDIA "Install sample media files" ON)
@@ -95,16 +97,18 @@ if (INSTALL_BASH_COMPLETION)
 endif (INSTALL_BASH_COMPLETION)
 
 if (WITH_SYSTEMD)
+    configure_file( init/gammu-smsd.service init/gammu-smsd.service )
     install (
-        FILES init/gammu-smsd.service
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/init/gammu-smsd.service
         DESTINATION "${SYSTEMD_SERVICES_INSTALL_DIR}"
         COMPONENT "systemd"
     )
 endif (WITH_SYSTEMD)
 
 if (INSTALL_LSB_INIT)
+    configure_file( init/gammu-smsd.lsb init/gammu-smsd.lsb )
     install (
-        FILES init/gammu-smsd.lsb
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/init/gammu-smsd.lsb
         DESTINATION "/etc/init.d"
         RENAME "gammu-smsd"
         COMPONENT "initscript"

--- a/contrib/init/gammu-smsd.lsb
+++ b/contrib/init/gammu-smsd.lsb
@@ -39,7 +39,7 @@ DESC="Gammu SMS Daemon"
 NAME=gammu-smsd
 # user which will run this daemon
 USER=gammu
-DAEMON=/usr/bin/$NAME
+DAEMON=${CMAKE_INSTALL_FULL_BINDIR}/$NAME
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 DAEMON_ARGS="--daemon --user $USER --pid $PIDFILE"

--- a/contrib/init/gammu-smsd.service
+++ b/contrib/init/gammu-smsd.service
@@ -6,9 +6,9 @@ After=mysql.service postgresql.service network-online.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/gammu-smsd
 # Run daemon as root user
-ExecStart=/usr/bin/gammu-smsd --pid=/var/run/gammu-smsd.pid --daemon
+ExecStart=${CMAKE_INSTALL_FULL_BINDIR}/gammu-smsd --pid=/var/run/gammu-smsd.pid --daemon
 # Run daemon as non-root user (set user/group in /etc/sysconfig/gammu-smsd)
-#ExecStart=/usr/bin/gammu-smsd --user=${GAMMU_USER} --group=${GAMMU_GROUP} --pid=/var/run/gammu-smsd.pid --daemon
+#ExecStart=${CMAKE_INSTALL_FULL_BINDIR}/gammu-smsd --user=${GAMMU_USER} --group=${GAMMU_GROUP} --pid=/var/run/gammu-smsd.pid --daemon
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStopPost=/bin/rm -f /var/run/gammu-smsd.pid
 Type=forking


### PR DESCRIPTION
systemd unit file and LSB script contain a hardcoded `/usr/bin` path prefix, which work when gammu is installed via a package manager. But it does not suit a manual installation from the sources, which installs in `/usr/local/bin`

This commit fixes it. CMake now configures (=tweaks) these files so that they contain the correct paths before installing.
Installation with the plain Makefile may have been somehow broken (but is it still supported?)

I have not tested building a .deb package. But I guess the paths are correctly configured in this case