### PR TITLE
irda: Fix poll.h include

### DIFF
--- a/libgammu/device/irda/irda.c
+++ b/libgammu/device/irda/irda.c
@@ -30,8 +30,8 @@
 #  include <unistd.h>
 #  include <fcntl.h>
 #  include <errno.h>
+#  include <poll.h>
 #  include <sys/time.h>
-#  include <sys/poll.h>
 #  include <sys/socket.h>
 #  include <sys/ioctl.h>
 typedef int SOCKET;


### PR DESCRIPTION
sys/poll is a GNU header. poll.h is the correct one. Fixes musl warning:

warning redirecting incorrect #include <sys/poll.h> to <poll.h>