### PR TITLE
Allow error on ATI3 and set manufacturer to Unknown

### DIFF
--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -2038,12 +2038,14 @@ GSM_Error ATGEN_GetManufacturer(GSM_StateMachine *s)
 
 	if (Priv->Manufacturer != 0 && s->Phone.Data.Manufacturer[0] != 0) return ERR_NONE;
 
+	strcpy(s->Phone.Data.Manufacturer, "Unknown");
+
 	error = ATGEN_WaitForAutoLen(s, "AT+CGMI\r", 0x00, 40, ID_GetManufacturer);
 
 	if (error != ERR_NONE) {
 		error = ATGEN_WaitForAutoLen(s, "ATI3\r", 0x00, 40, ID_GetManufacturer);
 	}
-	return error;
+	return ERR_NONE;
 }
 
 GSM_Error ATGEN_ReplyGetFirmware(GSM_Protocol_Message *msg, GSM_StateMachine *s)


### PR DESCRIPTION
This gets my Kazam Life B2 to be detected, even though the only thing that can
be done is setpower ON/OFF.

The identify command then gives:
```
Device               : /dev/ttyACM0
Manufacturer         : Unknown
Model                : MTK2 (MTK2)
Firmware             : SW06_KZM_LifeB2_B2D_2014_09_20, 2014/09/20 15:45
Unknown error.
```