### PR TITLE
Make sure power is enabled on startup

### DIFF
--- a/libgammu/gsmstate.c
+++ b/libgammu/gsmstate.c
@@ -902,6 +902,12 @@ autodetect:
 			return error;
 		}
 
+		error=s->Phone.Functions->SetPower(s, 1);
+		if (error != ERR_NONE && error != ERR_NOTSUPPORTED) {
+			GSM_LogError(s, "Init:Phone->SetPower" , error);
+			return error;
+		}
+
 		error=s->Phone.Functions->PostConnect(s);
 		if (error != ERR_NONE && error != ERR_NOTSUPPORTED) {
 			GSM_LogError(s, "Init:Phone->PostConnect" , error);


### PR DESCRIPTION
Attached patch makes sure power is enabled on startup.
At least D-Link DWL-157 initialize itself with radio disabled.

This change fixes issues #359, #515