### PR TITLE
Fixed D-Link dwm-157 +PSBEARER unknown answer

### DIFF
--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -6334,6 +6334,7 @@ GSM_Reply_Function ATGENReplyFunctions[] = {
 {ATGEN_GenericReplyIgnore,	"^STIN:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+ZUSIMR:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+SPNWNAME:"		,0x00,0x00,ID_IncomingFrame	 },
+{ATGEN_GenericReplyIgnore, 	"+PSBEARER:"	,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+ZEND"			,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_IncomingSMSInfo,		  "+CDSI:" 	 	,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore,	"+CLCC:"		,0x00,0x00,ID_IncomingFrame	 },

--- a/libgammu/protocol/at/at.c
+++ b/libgammu/protocol/at/at.c
@@ -142,6 +142,7 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 
 		/* D-Link */
 		{"+SPNWNAME:"	,1, ID_All}, /* +SPNWNAME: "432", "11", "Mci", "Mci" */
+		{"+PSBEARER:"	,1, ID_All}, /* +PSBEARER: 24, 0 */
 
 		/* ONDA */
 		{"+ZUSIMR:"	,1, ID_All}, /* +ZUSIMR:2 */


### PR DESCRIPTION
This PR fixes D-Link dwm-157 +PSBEARER unknown answer causing this Unknown frame error:
```
Entering GSM_SendSMS
Trying SMS PDU mode
SENDING frame type 0x00/length 0x0A/10
41A|54T|2B+|43C|4DM|47G|46F|3D=|300|0D                          AT+CMGF=0.
1 "+PSBEARER: 24, 0"
2 "+PSBEARER: 24, 0"
3 "+PSBEARER: 24, 0"
4 "AT+CMGF=0"
5 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0x4A/74
2B+|50P|53S|42B|45E|41A|52R|45E|52R|3A:|20 |322|344|2C,|20 |300 +PSBEARER: 24, 0
0D |0A |0D |0A |2B+|50P|53S|42B|45E|41A|52R|45E|52R|3A:|20 |322 ....+PSBEARER: 2
344|2C,|20 |300|0D |0A |0D |0A |2B+|50P|53S|42B|45E|41A|52R|45E 4, 0....+PSBEARE
52R|3A:|20 |322|344|2C,|20 |300|0D |0A |41A|54T|2B+|43C|4DM|47G R: 24, 0..AT+CMG
46F|3D=|300|0D |0D |0A |4FO|4BK|0D |0A                          F=0...OK..

UNKNOWN frame. Please report the error, see <https://wammu.eu/support/bugs/>. Thank you
LAST SENT frame type 0x00/length 10
41A|54T|2B+|43C|4DM|47G|46F|3D=|300|0D                          AT+CMGF=0.
RECEIVED frame type 0x00/length 0x4a/74
2B+|50P|53S|42B|45E|41A|52R|45E|52R|3A:|20 |322|344|2C,|20 |300 +PSBEARER: 24, 0
0D |0A |0D |0A |2B+|50P|53S|42B|45E|41A|52R|45E|52R|3A:|20 |322 ....+PSBEARER: 2
344|2C,|20 |300|0D |0A |0D |0A |2B+|50P|53S|42B|45E|41A|52R|45E 4, 0....+PSBEARE
52R|3A:|20 |322|344|2C,|20 |300|0D |0A |41A|54T|2B+|43C|4DM|47G R: 24, 0..AT+CMG
46F|3D=|300|0D |0D |0A |4FO|4BK|0D |0A                          F=0...OK..
```