### PR TITLE
Fixed SMS invalid location

### DIFF
--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -1089,6 +1089,7 @@ GSM_Error ATGEN_GetSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms)
 	if (error == ERR_NONE || error == ERR_CORRUPTED) {
 		getfolder = sms->SMS[0].Folder;
 		ATGEN_SetSMSLocation(s, &sms->SMS[0], folderid, location);
+		sms->SMS[0].Folder = getfolder;
 		if(sms->SMS[0].Memory != MEM_SR) {
 			sms->SMS[0].Memory = MEM_SM;
 			if (getfolder > 2) sms->SMS[0].Memory = MEM_ME;
@@ -2263,6 +2264,7 @@ GSM_Error ATGEN_ReplyDeleteSMSMessage(GSM_Protocol_Message *msg UNUSED, GSM_Stat
 
 GSM_Error ATGEN_DeleteSMS(GSM_StateMachine *s, GSM_SMSMessage *sms)
 {
+	sms->Folder = 0;
 	GSM_Error error;
 	GSM_MultiSMSMessage msms;
 	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;

--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -1089,7 +1089,6 @@ GSM_Error ATGEN_GetSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms)
 	if (error == ERR_NONE || error == ERR_CORRUPTED) {
 		getfolder = sms->SMS[0].Folder;
 		ATGEN_SetSMSLocation(s, &sms->SMS[0], folderid, location);
-		sms->SMS[0].Folder = getfolder;
 		if(sms->SMS[0].Memory != MEM_SR) {
 			sms->SMS[0].Memory = MEM_SM;
 			if (getfolder > 2) sms->SMS[0].Memory = MEM_ME;

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1574,7 +1574,6 @@ gboolean SMSD_ReadDeleteSMS(GSM_SMSDConfig *Config)
 
 		/* Delete processed messages */
 		for (j = 0; j < SortedSMS[i]->Number; j++) {
-			SortedSMS[i]->SMS[j].Folder = 0;
 			error = GSM_DeleteSMS(Config->gsm, &SortedSMS[i]->SMS[j]);
 			// Empty error can happen if deleting message several times
 			if (error != ERR_NONE && error != ERR_EMPTY) {


### PR DESCRIPTION
The  `ATGEN_SetSMSLocation` _Converts location from AT internal to Gammu API_, but when we need the real location for example for deleting purpose, this line in `ATGEN_GetSMS` overrides (I don't know why!) the returned location with old one and prevents returning real location:
https://github.com/gammu/gammu/blob/7eb89697616854e956b992181a7231bc03faa267/libgammu/phone/at/at-sms.c#L1092
that causes this error when deleting an SMS:
```
RECEIVED frame type 0x00/length 0x22/34
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|300|300|300|311|366|0D |0D  AT+CMGR=100016..
0A |2B+|43C|4DM|53S|20 |45E|52R|52R|4FO|52R|3A:|20 |333|322|311 .+CMS ERROR: 321
0D |0A                                                          ..
CMS Error 321: "invalid memory index"
GSM_DeleteSMS failed with error INVALIDLOCATION[24]: Invalid location. Maybe too high?
Leaving GSM_DeleteSMS
ERROR: Invalid location. Maybe too high?
```

I simply removed this line and the problem fixed.

Complete log:
BEFORE:
```
Entering GSM_GetSMS
Number = 0, Location = 16, Folder = 3
SMS folder 3 & location 16 -> ATGEN folder 2 & location 16
Getting SMS
SENDING frame type 0x00/length 0x0B/11
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D                      AT+CMGR=16.
1 "AT+CMGR=16"
2 "+CMGR: 1,, 67"
3 "079189<<TRUNCATED>>900630065"
4 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0xBA/186
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D |0D |0A |2B+|43C|4DM AT+CMGR=16...+CM
47G|52R|3A:|20 |311|2C,|2C,|20 |366|377|0D |0A |300|377|399|311 GR: 1,, 67..0791
<<TRUNCATED>>
366|355|0D |0A |0D |0A |4FO|4BK|0D |0A                          65....OK..
Parsing +CMGR: 1,, 67 with +CMGR: @i, @0
Parsed int 1
Number Length=7
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
SMS center number : "..."
SMS type: Deliver
Number Length=12
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
Remote number : "..."
SMS PID: 0x00
SMS DCS: 0x19
SMS class: 1
Decoding date & time: 7/2/2021 11:24:47 AM +0430 (Fri)
ATGEN folder 2 & location 16 -> SMS folder 0 & location 100016
Leaving GSM_GetSMS

Entering GSM_DeleteSMS
Location = 100016, Folder = 3
SMS folder 3 & location 100016 -> ATGEN folder 2 & location 100016
Requested memory type already set: ME
Getting SMS
SENDING frame type 0x00/length 0x0F/15
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|300|300|300|311|366|0D      AT+CMGR=100016.
1 "AT+CMGR=100016"
2 "+CMS ERROR: 321"
Checking line: +CMS ERROR: 321
AT reply state: 5
RECEIVED frame type 0x00/length 0x22/34
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|300|300|300|311|366|0D |0D  AT+CMGR=100016..
0A |2B+|43C|4DM|53S|20 |45E|52R|52R|4FO|52R|3A:|20 |333|322|311 .+CMS ERROR: 321
0D |0A                                                          ..
CMS Error 321: "invalid memory index"
GSM_DeleteSMS failed with error INVALIDLOCATION[24]: Invalid location. Maybe too high?
Leaving GSM_DeleteSMS
ERROR: Invalid location. Maybe too high?
```

AFTER:
```
Entering GSM_GetSMS
Number = 0, Location = 16, Folder = 3
SMS folder 3 & location 16 -> ATGEN folder 2 & location 16
Getting SMS
SENDING frame type 0x00/length 0x0B/11
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D                      AT+CMGR=16.
1 "AT+CMGR=16"
2 "+CMGR: 1,, 67"
3 "079189<<TRUNCATED>>6900630065"
4 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0xBA/186
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D |0D |0A |2B+|43C|4DM AT+CMGR=16...+CM
47G|52R|3A:|20 |311|2C,|2C,|20 |366|377|0D |0A |300|377|399|311 GR: 1,, 67..0791
<<TRUNCATED>>
366|355|0D |0A |0D |0A |4FO|4BK|0D |0A                          65....OK..
Parsing +CMGR: 1,, 67 with +CMGR: @i, @0
Parsed int 1
Number Length=7
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
SMS center number : "..."
SMS type: Deliver
Number Length=12
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
Remote number : "..."
SMS PID: 0x00
SMS DCS: 0x19
SMS class: 1
Decoding date & time: 7/2/2021 11:13:37 AM +0430 (Fri)
ATGEN folder 2 & location 16 -> SMS folder 0 & location 100016
Leaving GSM_GetSMS

Entering GSM_DeleteSMS
Location = 100016, Folder = 0
SMS folder 0 & location 100016 -> ATGEN folder 2 & location 16
Requested memory type already set: ME
Getting SMS
SENDING frame type 0x00/length 0x0B/11
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D                      AT+CMGR=16.
1 "AT+CMGR=16"
2 "+CMGR: 1,, 67"
3 "0791893<<TRUNCATED>>06900630065"
4 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0xBA/186
41A|54T|2B+|43C|4DM|47G|52R|3D=|311|366|0D |0D |0A |2B+|43C|4DM AT+CMGR=16...+CM
47G|52R|3A:|20 |311|2C,|2C,|20 |366|377|0D |0A |300|377|399|311 GR: 1,, 67..0791
<<TRUNCATED>>
366|355|0D |0A |0D |0A |4FO|4BK|0D |0A                          65....OK..
Parsing +CMGR: 1,, 67 with +CMGR: @i, @0
Parsed int 1
Number Length=7
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
SMS center number : "..."
SMS type: Deliver
Number Length=12
Number type 91 (1 0 0 1|0 0 0 1)
International number
Len 6
Remote number : "..."
SMS PID: 0x00
SMS DCS: 0x19
SMS class: 1
Decoding date & time: 7/2/2021 11:13:37 AM +0430 (Fri)
ATGEN folder 2 & location 16 -> SMS folder 0 & location 100016
SMS folder 0 & location 100016 -> ATGEN folder 2 & location 16
Setting SMS memory to "ME","ME"
SENDING frame type 0x00/length 0x12/18
41A|54T|2B+|43C|50P|4DM|53S|3D=|22"|4DM|45E|22"|2C,|22"|4DM|45E AT+CPMS="ME","ME
22"|0D                                                          ".
1 "AT+CPMS="ME","ME""
2 "+CPMS: 1, 50, 1, 50, 1, 65"
3 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0x36/54
41A|54T|2B+|43C|50P|4DM|53S|3D=|22"|4DM|45E|22"|2C,|22"|4DM|45E AT+CPMS="ME","ME
22"|0D |0D |0A |2B+|43C|50P|4DM|53S|3A:|20 |311|2C,|20 |355|300 "...+CPMS: 1, 50
2C,|20 |311|2C,|20 |355|300|2C,|20 |311|2C,|20 |366|355|0D |0A  , 1, 50, 1, 65..
0D |0A |4FO|4BK|0D |0A                                          ..OK..
Deleting SMS
SENDING frame type 0x00/length 0x0B/11
41A|54T|2B+|43C|4DM|47G|44D|3D=|311|366|0D                      AT+CMGD=16.
1 "AT+CMGD=16"
2 "OK"
Checking line: OK
AT reply state: 1
RECEIVED frame type 0x00/length 0x11/17
41A|54T|2B+|43C|4DM|47G|44D|3D=|311|366|0D |0D |0A |4FO|4BK|0D  AT+CMGD=16...OK.
0A                                                              .
SMS deleted OK
Leaving GSM_DeleteSMS
```