### PR TITLE
CNMIBroadcastProcedure can be 0 it is a valid procedure

### DIFF
--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -2809,9 +2809,6 @@ GSM_Error ATGEN_SetCNMI(GSM_StateMachine *s)
 	if (Priv->CNMIMode == 0) {
 		return ERR_NOTSUPPORTED;
 	}
-	if (Priv->CNMIBroadcastProcedure == 0) {
-		return ERR_NOTSUPPORTED;
-	}
 
 	length = sprintf(
 		buffer,


### PR DESCRIPTION
This code was blocking the setting of CNMI when GSM_ENABLE_CELLBROADCAST was enabled
