### PR TITLE
Skip garbage reply on AT+CMGL in PDU mode as in text mode

### DIFF
--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -1146,12 +1146,7 @@ GSM_Error ATGEN_ReplyGetMessageList(GSM_Protocol_Message *msg, GSM_StateMachine 
 			/*
 			 * Sometimes an SMS message will contain a line break. In SMS text
                          * mode we skip to the next line and try again to find +CMGL.
-			 * FIXME: Can we do the same for SMS PDU mode?
 			 */
-			if (Priv->SMSMode == SMS_AT_PDU) {
-				smprintf(s, "Can not find +CMGL:!\n");
-				return ERR_UNKNOWN;
-			}
 			continue;
 		}
 


### PR DESCRIPTION
THe D-Link DWM222 4G USB modem sends a garbage line before the reply to AT+CMGL. This case was handled in text mode but not in PDU mode, and this device exhibit the bad behavior in PDU mode too.

This change brings garbage skip behavior in PDU mode on par with text mode.