### PR TITLE
use /usr/lib/udev/rules.d for system or default rules

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -121,7 +121,7 @@ endif (INSTALL_LSB_INIT)
 if (INSTALL_UDEV_RULES)
     install (
         FILES udev/69-gammu-acl.rules
-        DESTINATION "/etc/udev/rules.d"
+        DESTINATION "/usr/lib/udev/rules.d"
         COMPONENT "udev"
         )
 else (INSTALL_UDEV_RULES)


### PR DESCRIPTION
and /etc/udev/rules.d may be used for the local or custom rules

this patch is from Fedora and can be upstreamed 