### PR TITLE
Modification in smsd/services/sql.c file for Delivery Report Logs

### DIFF
--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -808,7 +808,7 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 				}
 				db->FreeResult(Config, &res2);
 			} else {
-				SMSD_Log(DEBUG_ERROR, Config, "Failed to find SMS for TPMR=%i, Number=%s", sms->SMS[i].MessageReference, sms->SMS[i].Number);
+				SMSD_Log(DEBUG_ERROR, Config, "Failed to find SMS for TPMR=%i, Number=%s", sms->SMS[i].MessageReference, destinationnumber);
 			}
 			db->FreeResult(Config, &res);
 			continue;


### PR DESCRIPTION
The modification addresses the issue when destinationnumber gets  written as a blank string in the logs as follows.

<img width="647" height="26" alt="Screenshot 2025-07-30 at 9 56 21 PM" src="https://github.com/user-attachments/assets/b8f24b69-eb0c-4681-be97-ecf6698feba2" />

