### PR TITLE
Potential fix for code scanning alert no. 885: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/885](https://github.com/gammu/gammu/security/code-scanning/885)

In general, to fix this issue you should explicitly declare a `permissions:` block for the `GITHUB_TOKEN` at the workflow root (or per job), granting only the scopes required. For a typical CI workflow that just checks out code, builds, tests, and uploads coverage, `contents: read` is sufficient; other permissions (like `pull-requests: write`) are only needed if the workflow modifies PRs or similar.

The best fix here without changing functionality is to add a root‑level `permissions:` block right after the `on:` declaration so it applies to all jobs (`linux`, `windows`, `macos`) that do not override it. Based on the visible steps (checkout, building, testing, posting coverage via `codecov/codecov-action`), the workflow only needs read access to repository contents. Codecov v5 uses `GITHUB_TOKEN` only to fetch metadata (e.g., commit SHA, PR info) and does not need write scopes in this configuration. So we can safely set:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed; we only adjust the YAML in `.github/workflows/test.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
