### PR TITLE
Potential fix for code scanning alert no. 882: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,9 @@ name: Documentation
 
 on: [push, pull_request]
 
+permissions:
+  contents: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/882](https://github.com/gammu/gammu/security/code-scanning/882)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` has only the scopes needed. This avoids relying on repository or organization defaults and documents the intended permissions.

For this specific workflow in `.github/workflows/docs.yml`, the `docs` job needs to (1) read the repository contents for checkout, and (2) push built documentation to the `gh-pages` branch via `peaceiris/actions-gh-pages`, which requires `contents: write`. It does not manipulate issues, pull requests, or other resources, so we can safely restrict permissions to just `contents: write`. The cleanest fix is to add a `permissions` block at the workflow root (top level) so it applies to all jobs (currently only `docs`). Concretely, insert:

```yaml
permissions:
  contents: write
```

between the `on:` block (line 3) and the `jobs:` block (line 5). No imports or additional methods are needed; this is purely a YAML configuration change. Existing functionality (doc build and deployment) will continue to work because pushing to `gh-pages` via `GITHUB_TOKEN` still has the required `contents: write` permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
