### PR TITLE
Potential fix for code scanning alert no. 38: Multiplication result converted to larger type

### DIFF
--- a/libgammu/service/gsmcal.c
+++ b/libgammu/service/gsmcal.c
@@ -193,7 +193,8 @@ void GSM_GetCalendarRecurranceRepeat(GSM_Debug_Info *di, unsigned char *rec, uns
 		case 24:
 		case 24*7:
 		case 24*14:
-			GetTimeDifference(60*60*Recurrance*(endday[0]*256+endday[1]-1), &entry->Entries[entry->EntriesNum].Date, TRUE, 1);
+			GetTimeDifference((unsigned long)60 * 60 * Recurrance * (endday[0] * 256 + endday[1] - 1),
+			                  &entry->Entries[entry->EntriesNum].Date, TRUE, 1);
 			entry->EntriesNum++;
 			break;
 		case 24*30:


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/38](https://github.com/gammu/gammu/security/code-scanning/38)

In general, to fix “multiplication result converted to larger type” issues, ensure that at least one operand in the multiplication is explicitly cast to the larger integer type before the multiplication is evaluated. This promotes the entire expression to the wider type during arithmetic, preventing overflow in the narrower type before conversion.

Here, the problematic call is:

```c
GetTimeDifference(60*60*Recurrance*(endday[0]*256+endday[1]-1), &entry->Entries[entry->EntriesNum].Date, TRUE, 1);
```

`60`, `60`, `Recurrance`, and the result of `(endday[0]*256+endday[1]-1)` are all `int`. CodeQL indicates that `GetTimeDifference` expects an `unsigned long` (or other larger integer type) for its first parameter, so overflow can occur in the `int` multiplication before the result is converted to that larger type.

The best fix is to cast one of the early factors to `unsigned long` (or `time_t`/the exact wider type expected by `GetTimeDifference`, but we’ll follow the CodeQL description and use `unsigned long`). This ensures that the entire multiplication is evaluated as `unsigned long`. For clarity and minimal change, we can wrap the whole product in a cast starting from the first constant:

```c
GetTimeDifference((unsigned long)60 * 60 * Recurrance * (endday[0]*256 + endday[1] - 1),
                  &entry->Entries[entry->EntriesNum].Date, TRUE, 1);
```

This change is localized to the single line (around line 196) in `libgammu/service/gsmcal.c`. No new imports or helper methods are needed because we only use a standard C cast. Existing functionality is preserved for all values that previously fit in `int`, while eliminating the potential overflow for larger values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
