### PR TITLE
Potential fix for code scanning alert no. 874: Overrunning write

### DIFF
--- a/libgammu/misc/cfg.c
+++ b/libgammu/misc/cfg.c
@@ -248,11 +248,11 @@ GSM_Error INI_ReadFile(const char *FileName, gboolean Unicode, INI_Section **res
 		}
 		if (level == 5) {
 			if (Unicode) {
-				while (myiswspace(buffer2 + buffer2used - 2) && buffer2used > 0) {
+				while (buffer2used > 0 && myiswspace(buffer2 + buffer2used - 2)) {
 					buffer2used -= 2;
 				}
 			} else {
-				while (isspace(buffer2[buffer2used - 1]) && buffer2used > 0) {
+				while (buffer2used > 0 && isspace(buffer2[buffer2used - 1])) {
 					buffer2used -= 1;
 				}
 			}
@@ -266,19 +266,39 @@ GSM_Error INI_ReadFile(const char *FileName, gboolean Unicode, INI_Section **res
 				goto done;
                         }
 			if (Unicode) {
-				buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+2);
+				unsigned char *new_buffer1 = (unsigned char *)realloc(buffer1, buffer1used + 2);
+				if (new_buffer1 == NULL) {
+					error = ERR_MOREMEMORY;
+					goto done;
+				}
+				buffer1 = new_buffer1;
 				buffer1[buffer1used] 	= 0;
 				buffer1[buffer1used+1] 	= 0;
 				buffer1used		= buffer1used + 2;
-				buffer2 		= (unsigned char *)realloc(buffer2,buffer2used+2);
+				unsigned char *new_buffer2 = (unsigned char *)realloc(buffer2, buffer2used + 2);
+				if (new_buffer2 == NULL) {
+					error = ERR_MOREMEMORY;
+					goto done;
+				}
+				buffer2 = new_buffer2;
 				buffer2[buffer2used] 	= 0;
 				buffer2[buffer2used+1] 	= 0;
 				buffer2used		= buffer2used + 2;
 			} else {
-				buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+1);
+				unsigned char *new_buffer1 = (unsigned char *)realloc(buffer1, buffer1used + 1);
+				if (new_buffer1 == NULL) {
+					error = ERR_MOREMEMORY;
+					goto done;
+				}
+				buffer1 = new_buffer1;
 				buffer1[buffer1used] 	= 0x00;
 				buffer1used		= buffer1used + 1;
-				buffer2 		= (unsigned char *)realloc(buffer2,buffer2used+1);
+				unsigned char *new_buffer2 = (unsigned char *)realloc(buffer2, buffer2used + 1);
+				if (new_buffer2 == NULL) {
+					error = ERR_MOREMEMORY;
+					goto done;
+				}
+				buffer2 = new_buffer2;
 				buffer2[buffer2used] 	= 0x00;
 				buffer2used		= buffer2used + 1;
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/874](https://github.com/gammu/gammu/security/code-scanning/874)

General fix: Always check the result of `realloc` before using it and avoid losing the original pointer; only update the live pointer and size after confirming success. Also, ensure index/offset checks are performed before dereferencing pointers, particularly in loops that walk backward from the end of a buffer.

Concrete changes in `libgammu/misc/cfg.c` around the provided snippet:

1. In the Unicode and non-Unicode branches where `buffer1` and `buffer2` are resized, introduce temporary pointers `new_buffer1` and `new_buffer2` to hold the result from `realloc`. If `realloc` returns `NULL`, set `error = ERR_MOREMEMORY` and `goto done` without modifying the original buffers. If successful, assign `buffer1 = new_buffer1;` (and similarly for `buffer2`) and then write the terminators and adjust `buffer1used`/`buffer2used`.

2. In the Unicode whitespace-trimming loop, change the `while` condition to check `buffer2used > 0` before computing `buffer2 + buffer2used - 2`. That is, reorder the conjuncts: `while (buffer2used > 0 && myiswspace(buffer2 + buffer2used - 2))`. This ensures we don't create an invalid pointer expression when `buffer2used` is 0.

These changes stay confined to the shown snippet, do not alter the logical behavior (they only handle allocation failures and reordering of checks), and remove the risk of overrun/invalid memory access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
