### PR TITLE
Potential fix for code scanning alert no. 873: Overrunning write

### DIFF
--- a/libgammu/misc/cfg.c
+++ b/libgammu/misc/cfg.c
@@ -32,6 +32,7 @@ GSM_Error INI_ReadFile(const char *FileName, gboolean Unicode, INI_Section **res
         INI_Section 	*INI_info = NULL, *INI_head = NULL, *heading;
         INI_Entry 	*entry;
 	GSM_Error	error = ERR_NONE;
+	unsigned char	*new_buffer1;
 
 	*result = NULL;
 
@@ -127,12 +128,22 @@ GSM_Error INI_ReadFile(const char *FileName, gboolean Unicode, INI_Section **res
 						break;
 					}
 					if (Unicode) {
-						buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+2);
+						new_buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+2);
+						if (new_buffer1 == NULL) {
+							error = ERR_MOREMEMORY;
+							goto done;
+						}
+						buffer1			= new_buffer1;
 						buffer1[buffer1used] 	= 0;
 						buffer1[buffer1used+1] 	= 0;
 						buffer1used		= buffer1used + 2;
 					} else {
-						buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+1);
+						new_buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+1);
+						if (new_buffer1 == NULL) {
+							error = ERR_MOREMEMORY;
+							goto done;
+						}
+						buffer1			= new_buffer1;
 						buffer1[buffer1used] 	= 0x00;
 						buffer1used		= buffer1used + 1;
 					}
@@ -156,12 +167,22 @@ GSM_Error INI_ReadFile(const char *FileName, gboolean Unicode, INI_Section **res
 					break;
 				}
 				if (Unicode) {
-					buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+2);
+					new_buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+2);
+					if (new_buffer1 == NULL) {
+						error = ERR_MOREMEMORY;
+						goto done;
+					}
+					buffer1			= new_buffer1;
 					buffer1[buffer1used] 	= ch[0];
 					buffer1[buffer1used+1] 	= ch[1];
 					buffer1used		= buffer1used + 2;
 				} else {
-					buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+1);
+					new_buffer1 		= (unsigned char *)realloc(buffer1,buffer1used+1);
+					if (new_buffer1 == NULL) {
+						error = ERR_MOREMEMORY;
+						goto done;
+					}
+					buffer1			= new_buffer1;
 					buffer1[buffer1used] 	= ch[1];
 					buffer1used		= buffer1used + 1;
 				}


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/873](https://github.com/gammu/gammu/security/code-scanning/873)

In general, to prevent overrunning writes when using manual dynamic buffers, you must (1) check the result of each allocation/reallocation before writing through the pointer, and (2) ensure that the size you pass to allocation functions cannot overflow and is consistent with the number of bytes you write and later copy. Also, you must only use the new pointer returned by `realloc`; if it returns `NULL` the old buffer remains allocated but you must not overwrite it using the (now discarded) pointer value.

The best localized fix here is:

1. Introduce a temporary pointer for `realloc` calls on `buffer1` (`unsigned char *new_buffer1;`).
2. After each `realloc`, check if the result is `NULL`. If so, set `error = ERR_MOREMEMORY;` and jump to `done:` to clean up (this is already the pattern used elsewhere).
3. Only update `buffer1` and write to it after confirming `realloc` succeeded.
4. Before computing `buffer1used + 1` or `buffer1used + 2`, optionally guard against integer overflow by checking that `buffer1used` is not so large that adding the increment would wrap; this can be done cheaply using `SIZE_MAX` if `<limits.h>` is acceptable, but since we must avoid new imports unless well‑known, and this code already uses `size_t` for other sizes, we can leave integer overflow protection out to avoid broader changes and focus on the clear undefined behavior from unchecked `realloc`. This keeps behavior identical in normal conditions while removing the dangerous cases.

Concretely:

- In the branch at lines 125–138 (closing `]`), wrap the `realloc` calls at 130 and 135 with a temporary `unsigned char *new_buffer1` and a `NULL` check before using `buffer1`.
- In the branch at lines 158–167 (accumulating section name characters), do the same around the `realloc` calls at 159 and 164.
- Declare `unsigned char *new_buffer1;` near the other local variables in `INI_ReadFile`.
- Do not change the semantics of how `buffer1used` is updated or the size passed to `malloc`/`memcpy`; just make those operations safe in low‑memory conditions.

This preserves existing behavior for successful allocations and fixes the memory safety hazard that CodeQL is warning about.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
