### PR TITLE
Potential fix for code scanning alert no. 717: Unbounded write

### DIFF
--- a/libgammu/gsmstate.c
+++ b/libgammu/gsmstate.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <assert.h>
+#include <stdio.h>
 
 #include <gammu-call.h>
 #include <gammu-settings.h>
@@ -1337,52 +1338,52 @@ GSM_Error GSM_FindGammuRC (INI_Section **result, const char *force_config)
 #ifdef WIN32
 	/* Get Windows application data path */
 	if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, SHGFP_TYPE_CURRENT, configfile))) {
-		strcat(configfile, GAMMURC_NAME);
-
-		error = GSM_TryReadGammuRC(configfile, result);
-		if (error == ERR_NONE) return ERR_NONE;
+		int n = snprintf(configfile, sizeof(configfile), "%s%s", configfile, GAMMURC_NAME);
+		if (n > 0 && (size_t)n < sizeof(configfile)) {
+			error = GSM_TryReadGammuRC(configfile, result);
+			if (error == ERR_NONE) return ERR_NONE;
+		}
 	}
 #endif
 
 	/* XDG paths */
 	envpath = getenv("XDG_CONFIG_HOME");
 	if (envpath) {
-		strcpy(configfile, envpath);
-		strcat(configfile, XDG_GAMMURC_NAME);
-
-		error = GSM_TryReadGammuRC(configfile, result);
-		if (error == ERR_NONE) return ERR_NONE;
+		int n = snprintf(configfile, sizeof(configfile), "%s%s", envpath, XDG_GAMMURC_NAME);
+		if (n > 0 && (size_t)n < sizeof(configfile)) {
+			error = GSM_TryReadGammuRC(configfile, result);
+			if (error == ERR_NONE) return ERR_NONE;
+		}
 	} else {
 		envpath  = getenv("HOME");
 		if (envpath) {
-			strcpy(configfile, envpath);
-			strcat(configfile, "/.config");
-			strcat(configfile, XDG_GAMMURC_NAME);
-
-			error = GSM_TryReadGammuRC(configfile, result);
-			if (error == ERR_NONE) return ERR_NONE;
+			int n = snprintf(configfile, sizeof(configfile), "%s/.config%s", envpath, XDG_GAMMURC_NAME);
+			if (n > 0 && (size_t)n < sizeof(configfile)) {
+				error = GSM_TryReadGammuRC(configfile, result);
+				if (error == ERR_NONE) return ERR_NONE;
+			}
 		}
 	}
 
 	/* Try home from environment */
 	envpath  = getenv("HOME");
 	if (envpath) {
-		strcpy(configfile, envpath);
-		strcat(configfile, GAMMURC_NAME);
-
-		error = GSM_TryReadGammuRC(configfile, result);
-		if (error == ERR_NONE) return ERR_NONE;
+		int n = snprintf(configfile, sizeof(configfile), "%s%s", envpath, GAMMURC_NAME);
+		if (n > 0 && (size_t)n < sizeof(configfile)) {
+			error = GSM_TryReadGammuRC(configfile, result);
+			if (error == ERR_NONE) return ERR_NONE;
+		}
 	}
 
 #if defined(HAVE_GETPWUID) && defined(HAVE_GETUID)
 	/* Tru home from passwd */
 	pwent = getpwuid(getuid());
 	if (pwent != NULL) {
-		strcpy(configfile, pwent->pw_dir);
-		strcat(configfile, GAMMURC_NAME);
-
-		error = GSM_TryReadGammuRC(configfile, result);
-		if (error == ERR_NONE) return ERR_NONE;
+		int n = snprintf(configfile, sizeof(configfile), "%s%s", pwent->pw_dir, GAMMURC_NAME);
+		if (n > 0 && (size_t)n < sizeof(configfile)) {
+			error = GSM_TryReadGammuRC(configfile, result);
+			if (error == ERR_NONE) return ERR_NONE;
+		}
 	}
 
 #endif


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/717](https://github.com/gammu/gammu/security/code-scanning/717)

To fix the problem, all uses of `strcpy`/`strcat` that write environment-derived data into `configfile` should be replaced with length-checked variants that ensure we never write more than the `configfile` buffer can hold, and that always NUL-terminate. The same applies to any platform-specific path construction using `configfile`, since the size of the buffer is not enforced locally.

The best minimal-change fix is to use `snprintf`, which is already widely available, combined with `sizeof(configfile)` so that the maximum number of bytes written cannot exceed the buffer. For simple patterns like `strcpy(configfile, envpath); strcat(configfile, XDG_GAMMURC_NAME);` we can replace them with a single `snprintf(configfile, sizeof(configfile), "%s%s", envpath, XDG_GAMMURC_NAME);`. For the cascaded `strcat` sequence used when appending `"/.config"` and then `XDG_GAMMURC_NAME`, we can also collapse it into a single `snprintf` with `"%s/.config%s"`. Where only `GAMMURC_NAME` is appended, we similarly use `snprintf(configfile, sizeof(configfile), "%s%s", envpath_or_pw_dir, GAMMURC_NAME);`. For the Windows `SHGetFolderPath` case, we should stop using `strcat` directly on the buffer returned by `SHGetFolderPath` and instead reformat the complete path into `configfile` with `snprintf(configfile, sizeof(configfile), "%s%s", configfile, GAMMURC_NAME);`. After each `snprintf`, we can check its return value and, if it indicates truncation or error (`< 0` or `>= sizeof(configfile)`), skip trying to read the config file (or handle as appropriate). This preserves existing functionality while adding proper bounds checking.

Concretely, within `libgammu/gsmstate.c` around lines 1337–1386, update each path construction:

- Replace:
  - `strcat(configfile, GAMMURC_NAME);` (Windows block)
  - `strcpy(configfile, envpath); strcat(configfile, XDG_GAMMURC_NAME);`
  - `strcpy(configfile, envpath); strcat(configfile, "/.config"); strcat(configfile, XDG_GAMMURC_NAME);`
  - `strcpy(configfile, envpath); strcat(configfile, GAMMURC_NAME);`
  - `strcpy(configfile, pwent->pw_dir); strcat(configfile, GAMMURC_NAME);`
- With calls to `snprintf(configfile, sizeof(configfile), ...)` that build the entire string in one shot, and optional checks that the result fits.

No new headers are needed because `<stdio.h>` is not yet included in the snippet; we must add it to use `snprintf`. We should not alter behavior beyond avoiding overflow and optionally skipping the read if truncation might have occurred.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
