### PR TITLE
Potential fix for code scanning alert no. 726: Use of potentially dangerous function

### DIFF
--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -572,7 +572,7 @@ static GSM_Error SMSDFiles_CreateOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDCo
 	unsigned char FileName[PATH_MAX], FullName[PATH_MAX], ext[17], buffer[64], buffer2[400];
 	FILE *file = NULL;
 	time_t rawtime;
-	struct tm *timeinfo;
+	struct tm timeinfo;
 
 #ifdef GSM_ENABLE_BACKUP
 	GSM_Error error;
@@ -581,7 +581,7 @@ static GSM_Error SMSDFiles_CreateOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDCo
 
 	j = 0;
 	time(&rawtime);
-	timeinfo = localtime(&rawtime);
+	localtime_r(&rawtime, &timeinfo);
 
 	for (i = 0; i < sms->Number; i++) {
 		if (strcasecmp(Config->outboxformat, "detail") == 0) {
@@ -595,7 +595,7 @@ static GSM_Error SMSDFiles_CreateOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDCo
 		for (j = 0; j < 100; j++) {
 			sprintf(FileName,
 				"OUTC%04d%02d%02d_%02d%02d%02d_00_%s_sms%d.%s",
-				1900 + timeinfo->tm_year, timeinfo->tm_mon + 1, timeinfo->tm_mday, timeinfo->tm_hour, timeinfo->tm_min, timeinfo->tm_sec, buffer2, j, ext);
+				1900 + timeinfo.tm_year, timeinfo.tm_mon + 1, timeinfo.tm_mday, timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, buffer2, j, ext);
 			strcpy(FullName, Config->outboxpath);
 			strcat(FullName, FileName);
 			fd = open(FullName, O_CREAT | O_EXCL, 0644);


### PR DESCRIPTION
Potential fix for [https://github.com/gammu/gammu/security/code-scanning/726](https://github.com/gammu/gammu/security/code-scanning/726)

In general, the fix is to avoid using the non-reentrant `localtime` and instead use a re-entrant variant where the caller supplies storage for the `struct tm`. On POSIX systems this is `localtime_r(const time_t *restrict, struct tm *restrict)`. This eliminates the shared static buffer and makes the code safe in multi-threaded contexts.

For this specific function in `smsd/services/files.c`, we should:
- Replace the `struct tm *timeinfo;` declaration with `struct tm timeinfo;`.
- Replace `timeinfo = localtime(&rawtime);` with a call to `localtime_r(&rawtime, &timeinfo);`.
- Update all subsequent uses from pointer syntax (`timeinfo->field`) to struct syntax (`timeinfo.field`).

The code already includes `<time.h>`, so no new includes are necessary. All changes are local to `SMSDFiles_CreateOutboxSMS` around lines 574–585. This preserves existing functionality (same time fields, same formatting) while removing the use of shared static storage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
