### PR TITLE
Fix usage of compgen in bash-completion setting

### DIFF
--- a/contrib/bash-completion/gammu
+++ b/contrib/bash-completion/gammu
@@ -22,7 +22,7 @@ _gammu_commands()
 
 _gammu()
 {
-    cur=${COMP_WORDS[COMP_CWORD]}
+    local cur=${COMP_WORDS[COMP_CWORD]}
     COMPREPLY=( $( compgen -W "$(_gammu_commands)" -- "$cur" ) )
 }
 

--- a/contrib/bash-completion/gammu
+++ b/contrib/bash-completion/gammu
@@ -23,7 +23,7 @@ _gammu_commands()
 _gammu()
 {
     cur=${COMP_WORDS[COMP_CWORD]}
-    COMPREPLY=( $( compgen -W "$(_gammu_commands)" -- $cur ) )
+    COMPREPLY=( $( compgen -W "$(_gammu_commands)" -- "$cur" ) )
 }
 
 complete -F _gammu -o default gammu

--- a/contrib/bash-completion/gammu
+++ b/contrib/bash-completion/gammu
@@ -23,7 +23,7 @@ _gammu_commands()
 _gammu()
 {
     cur=${COMP_WORDS[COMP_CWORD]}
-    COMPREPLY=( $( compgen -W "$(_gammu_commands)" $cur ) )
+    COMPREPLY=( $( compgen -W "$(_gammu_commands)" -- $cur ) )
 }
 
 complete -F _gammu -o default gammu


### PR DESCRIPTION
The usage of the compgen in the bash-completion setting at `contrib/bash-completion/gammu` has an issue. The details are described in the commit message of the first commit. Please check the commit message.

I also included fixes for two other minor issues in the second and third commits. The explanations are again described in the commit messages. If you require submitting these as separate pull requests, please let me know, and I'll be happy to separate them.