### PR TITLE
fix(smsd): prevent command injection in run hooks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -19,6 +19,11 @@ the issue.
 ChangeLog
 =========
 
+Unreleased
+
+[-] * Prevent command injection through SMSD RunOn hook arguments on POSIX
+      and Windows.
+
 20260209 - 1.43.2
 
 [-] * Add Minimal binary build for Windows without third-party dependencies.

--- a/docs/man/gammu-backup.5
+++ b/docs/man/gammu-backup.5
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-BACKUP" "5" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-BACKUP" "5" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-backup \- gammu(1) backup file format.
 .sp

--- a/docs/man/gammu-config.1
+++ b/docs/man/gammu-config.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-CONFIG" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-CONFIG" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-config \- Gammu configurator
 .SH SYNOPSIS

--- a/docs/man/gammu-detect.1
+++ b/docs/man/gammu-detect.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-DETECT" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-DETECT" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-detect \- Gammu device detection
 .sp

--- a/docs/man/gammu-smsbackup.5
+++ b/docs/man/gammu-smsbackup.5
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSBACKUP" "5" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSBACKUP" "5" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsbackup \- gammu(1) SMS backup file format.
 .sp

--- a/docs/man/gammu-smsd-dbi.7
+++ b/docs/man/gammu-smsd-dbi.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-DBI" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-DBI" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-dbi \- gammu-smsd(1) backend using DBI abstraction layer to use any supported database as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-files.7
+++ b/docs/man/gammu-smsd-files.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-FILES" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-FILES" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-files \- gammu-smsd(1) backend using filesystem as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-inject.1
+++ b/docs/man/gammu-smsd-inject.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-INJECT" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-INJECT" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-inject \- Inject messages into queue of SMS daemon for Gammu
 .SH SYNOPSIS

--- a/docs/man/gammu-smsd-monitor.1
+++ b/docs/man/gammu-smsd-monitor.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-MONITOR" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-MONITOR" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-monitor \- Monitor state of SMS daemon for Gammu
 .SH SYNOPSIS

--- a/docs/man/gammu-smsd-mysql.7
+++ b/docs/man/gammu-smsd-mysql.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-MYSQL" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-MYSQL" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-mysql \- gammu-smsd(1) backend using MySQL database server as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-null.7
+++ b/docs/man/gammu-smsd-null.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-NULL" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-NULL" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-null \- gammu-smsd(1) backend not storing messages
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-odbc.7
+++ b/docs/man/gammu-smsd-odbc.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-ODBC" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-ODBC" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-odbc \- gammu-smsd(1) backend using ODBC abstraction layer to use any supported database as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-pgsql.7
+++ b/docs/man/gammu-smsd-pgsql.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-PGSQL" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-PGSQL" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-pgsql \- gammu-smsd(1) backend using PostgreSQL database server as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-run.7
+++ b/docs/man/gammu-smsd-run.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-RUN" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-RUN" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-run \- documentation for RunOnReceive directive
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-sql.7
+++ b/docs/man/gammu-smsd-sql.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-SQL" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-SQL" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-sql \- gammu-smsd(1) backend using SQL abstraction layer to use any supported database as a message storage
 .SH DESCRIPTION

--- a/docs/man/gammu-smsd-tables.7
+++ b/docs/man/gammu-smsd-tables.7
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD-TABLES" "7" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD-TABLES" "7" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd-tables \- description of tables for database backends of gammu-smsd(1)
 .sp

--- a/docs/man/gammu-smsd.1
+++ b/docs/man/gammu-smsd.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSD" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSD" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsd \- SMS daemon for Gammu
 .SH SYNOPSIS

--- a/docs/man/gammu-smsdrc.5
+++ b/docs/man/gammu-smsdrc.5
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU-SMSDRC" "5" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU-SMSDRC" "5" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu-smsdrc \- gammu-smsd(1) configuration file
 .SH DESCRIPTION
@@ -455,11 +455,18 @@ SMSC from phone, but sometimes this fails (try \fBgammu getsmsc\fP).
 .B RunOnReceive
 Executes a program after receiving message.
 .sp
-This parameter is executed through shell, so you might need to escape some
-special characters and you can include any number of parameters. Additionally
-parameters with identifiers of received messages are appended to the command
-line. The identifiers depend on used service backend, typically it is ID of
-inserted row for database backends or file name for file based backends.
+The configured command can include any number of parameters. On POSIX systems
+it is executed through the shell, so special characters in the configured
+command need to be escaped accordingly. Identifiers of received messages are
+passed as separate literal arguments and are not interpreted as shell syntax.
+The identifiers depend on the service backend; typically they are IDs of
+inserted rows for database backends or file names for file based backends.
+.sp
+On Windows, arguments containing command processor metacharacters, variable
+expansion characters, or control characters are rejected and the hook is not
+started. This prevents caller\-controlled values from being interpreted when a
+configured command invokes \fBcmd.exe\fP or a batch file. This restriction
+applies to all \fBRunOn\fP directives.
 .sp
 Gammu SMSD waits for the script to terminate. If you make some time consuming
 there, it will make SMSD not receive new messages. However to limit breakage
@@ -481,9 +488,9 @@ Executes a program on failure.
 This can be used to proactively react on some failures or to interactively
 detect failure of sending message.
 .sp
-The program will receive optional parameter, which can currently be either
-\fBINIT\fP (meaning failure during phone initialization) or message ID,
-which would indicate error while sending the message.
+The program will receive an optional literal argument, which can currently
+be either \fBINIT\fP (meaning failure during phone initialization) or a
+message ID, which indicates an error while sending the message.
 .sp
 \fBNote:\fP
 .INDENT 7.0
@@ -500,8 +507,9 @@ Added in version 1.36.4.
 .sp
 Executes a program after sending message.
 .sp
-The program will receive optional parameter a message ID and environment
-with message details as described in RunOnReceive Directive \%<#\:gammu-smsd-run>\&.
+The program will receive an optional literal argument containing a message
+ID and an environment with message details as described in
+RunOnReceive Directive \%<#\:gammu-smsd-run>\&.
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -511,8 +519,8 @@ Added in version 1.38.5.
 .sp
 Executes a program after cancelling incoming call.
 .sp
-The program will receive a parameter with a phone number of the call.
-This requires \fBHangupCalls\fP to be enabled.
+The program will receive a literal argument containing the phone number of
+the call. This requires \fBHangupCalls\fP to be enabled.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/docs/man/gammu.1
+++ b/docs/man/gammu.1
@@ -29,7 +29,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMU" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMU" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammu \- Does some neat things with your cellular phone or modem.
 .SH SYNOPSIS

--- a/docs/man/gammurc.5
+++ b/docs/man/gammurc.5
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "GAMMURC" "5" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "GAMMURC" "5" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 gammurc \- gammu(1) configuration file
 .SH SYNOPSIS

--- a/docs/man/jadmaker.1
+++ b/docs/man/jadmaker.1
@@ -28,7 +28,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "JADMAKER" "1" "Feb 09, 2026" "1.43.2" "Gammu"
+.TH "JADMAKER" "1" "Jul 25, 2026" "1.43.2" "Gammu"
 .SH NAME
 jadmaker \- JAD File Generator
 .SH SYNOPSIS

--- a/docs/manual/smsd/config.rst
+++ b/docs/manual/smsd/config.rst
@@ -351,11 +351,18 @@ General parameters of SMS daemon
 
     Executes a program after receiving message.
 
-    This parameter is executed through shell, so you might need to escape some
-    special characters and you can include any number of parameters. Additionally
-    parameters with identifiers of received messages are appended to the command
-    line. The identifiers depend on used service backend, typically it is ID of
-    inserted row for database backends or file name for file based backends.
+    The configured command can include any number of parameters. On POSIX systems
+    it is executed through the shell, so special characters in the configured
+    command need to be escaped accordingly. Identifiers of received messages are
+    passed as separate literal arguments and are not interpreted as shell syntax.
+    The identifiers depend on the service backend; typically they are IDs of
+    inserted rows for database backends or file names for file based backends.
+
+    On Windows, arguments containing command processor metacharacters, variable
+    expansion characters, or control characters are rejected and the hook is not
+    started. This prevents caller-controlled values from being interpreted when a
+    configured command invokes ``cmd.exe`` or a batch file. This restriction
+    applies to all ``RunOn`` directives.
 
     Gammu SMSD waits for the script to terminate. If you make some time consuming
     there, it will make SMSD not receive new messages. However to limit breakage
@@ -375,9 +382,9 @@ General parameters of SMS daemon
     This can be used to proactively react on some failures or to interactively
     detect failure of sending message.
 
-    The program will receive optional parameter, which can currently be either
-    ``INIT`` (meaning failure during phone initialization) or message ID,
-    which would indicate error while sending the message.
+    The program will receive an optional literal argument, which can currently
+    be either ``INIT`` (meaning failure during phone initialization) or a
+    message ID, which indicates an error while sending the message.
 
     .. note:: The environment with message (as is in :config:option:`RunOnReceive`) is not passed to the command.
 
@@ -387,8 +394,9 @@ General parameters of SMS daemon
 
     Executes a program after sending message.
 
-    The program will receive optional parameter a message ID and environment
-    with message details as described in :ref:`gammu-smsd-run`.
+    The program will receive an optional literal argument containing a message
+    ID and an environment with message details as described in
+    :ref:`gammu-smsd-run`.
 
 .. config:option:: RunOnIncomingCall
 
@@ -396,8 +404,8 @@ General parameters of SMS daemon
 
     Executes a program after cancelling incoming call.
 
-    The program will receive a parameter with a phone number of the call.
-    This requires :config:option:`HangupCalls` to be enabled.
+    The program will receive a literal argument containing the phone number of
+    the call. This requires :config:option:`HangupCalls` to be enabled.
 
 .. config:option:: IncludeNumbersFile
 

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1044,24 +1044,102 @@ gboolean SMSD_CheckSecurity(GSM_SMSDConfig *Config)
 /**
  * Prepares a command line for RunOn() function to execute user command.
  */
-char *SMSD_RunOnCommand(const char *locations, const char *command)
+char *SMSD_RunOnCommand(const char *command, const GSM_StringArray *arguments)
 {
 	char *result;
 	size_t len;
 
 	assert(command != NULL);
 
-	if (locations == NULL) {
-		result =  strdup(command);
+	if (arguments == NULL || arguments->used == 0) {
+		result = strdup(command);
 		assert(result != NULL);
 		return result;
 	}
 
-	len = strlen(locations) + strlen(command) + 4;
+#ifdef WIN32
+	{
+		size_t i, j, backslashes, pos;
+
+		/*
+		 * CreateProcess does not separate the executable command line from
+		 * its arguments. Reject characters which can escape quoting or be
+		 * expanded when the configured command invokes cmd.exe.
+		 */
+		for (i = 0; i < arguments->used; i++) {
+			for (j = 0; arguments->data[i][j] != 0; j++) {
+				unsigned char character = arguments->data[i][j];
+				if (character <= 0x1f || character == 0x7f ||
+				    strchr("\"%!^&|<>()", character) != NULL) {
+					return NULL;
+				}
+			}
+		}
+
+		/* Quote arguments according to the Windows C runtime parsing rules. */
+		len = strlen(command) + 1;
+		for (i = 0; i < arguments->used; i++) {
+			len += 3;
+			backslashes = 0;
+			for (j = 0; arguments->data[i][j] != 0; j++) {
+				if (arguments->data[i][j] == '\\') {
+					backslashes++;
+				} else if (arguments->data[i][j] == '"') {
+					len += 2 * backslashes + 2;
+					backslashes = 0;
+				} else {
+					len += backslashes + 1;
+					backslashes = 0;
+				}
+			}
+			len += 2 * backslashes;
+		}
+
+		result = (char *)malloc(len);
+		assert(result != NULL);
+		strcpy(result, command);
+		pos = strlen(result);
+
+		for (i = 0; i < arguments->used; i++) {
+			result[pos++] = ' ';
+			result[pos++] = '"';
+			backslashes = 0;
+			for (j = 0; arguments->data[i][j] != 0; j++) {
+				if (arguments->data[i][j] == '\\') {
+					backslashes++;
+				} else if (arguments->data[i][j] == '"') {
+					while (backslashes > 0) {
+						result[pos++] = '\\';
+						result[pos++] = '\\';
+						backslashes--;
+					}
+					result[pos++] = '\\';
+					result[pos++] = '"';
+				} else {
+					while (backslashes > 0) {
+						result[pos++] = '\\';
+						backslashes--;
+					}
+					result[pos++] = arguments->data[i][j];
+				}
+			}
+			while (backslashes > 0) {
+				result[pos++] = '\\';
+				result[pos++] = '\\';
+				backslashes--;
+			}
+			result[pos++] = '"';
+		}
+		result[pos] = 0;
+	}
+#else
+	/* Runtime arguments are supplied as shell positional parameters. */
+	len = strlen(command) + strlen(" \"$@\"") + 1;
 	result = (char *)malloc(len);
 	assert(result != NULL);
 
-	snprintf(result, len, "%s %s", command, locations);
+	snprintf(result, len, "%s \"$@\"", command);
+#endif
 	return result;
 }
 
@@ -1072,7 +1150,7 @@ char *SMSD_RunOnCommand(const char *locations, const char *command)
 /**
  * Fills in environment with information about messages.
  */
-void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const char *locations)
+void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config)
 {
 	GSM_MultiPartSMSInfo SMSInfo;
 	char buffer[100], name[100];
@@ -1145,18 +1223,22 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
  *
  * This is Windows variant.
  */
-gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const char *locations, const char *event)
+gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event)
 {
 	BOOL ret;
 	STARTUPINFO si;
 	PROCESS_INFORMATION pi;
 	char *cmdline;
 
-	cmdline = SMSD_RunOnCommand(locations, command);
+	cmdline = SMSD_RunOnCommand(command, arguments);
+	if (cmdline == NULL) {
+		SMSD_Log(DEBUG_ERROR, Config, "Refusing run on %s with arguments unsafe for the Windows command processor", event);
+		return FALSE;
+	}
 
 	/* Prepare environment */
 	if (sms != NULL) {
-		SMSD_RunOnReceiveEnvironment(sms, Config, locations);
+		SMSD_RunOnReceiveEnvironment(sms, Config);
 	}
 
 	ZeroMemory(&si, sizeof(si));
@@ -1192,7 +1274,7 @@ gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfi
  *
  * This is POSIX variant.
  */
-gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const char *locations, const char *event)
+gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event)
 {
 	int pid;
 	int pipefd[2];
@@ -1200,6 +1282,8 @@ gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfi
 	pid_t w;
 	int status;
 	char *cmdline;
+	char **argv;
+	size_t argument_index;
 	ssize_t bytes;
 	char buffer[4097];
 	gboolean result = FALSE;
@@ -1280,12 +1364,23 @@ out:
 
 	/* Prepare environment */
 	if (sms != NULL) {
-		SMSD_RunOnReceiveEnvironment(sms, Config, locations);
+		SMSD_RunOnReceiveEnvironment(sms, Config);
 	}
 
 	/* Calculate command line */
-	cmdline = SMSD_RunOnCommand(locations, command);
+	cmdline = SMSD_RunOnCommand(command, arguments);
 	SMSD_Log(DEBUG_INFO, Config, "Starting run on %s: %s", event, cmdline);
+
+	argv = (char **)malloc((4 + (arguments == NULL ? 0 : arguments->used) + 1) * sizeof(char *));
+	assert(argv != NULL);
+	argv[0] = (char *)"sh";
+	argv[1] = (char *)"-c";
+	argv[2] = cmdline;
+	argv[3] = (char *)"sh";
+	for (argument_index = 0; arguments != NULL && argument_index < arguments->used; argument_index++) {
+		argv[argument_index + 4] = arguments->data[argument_index];
+	}
+	argv[argument_index + 4] = NULL;
 
 	/* Close all file descriptors */
 	for (i = 0; i < 255; i++) {
@@ -1299,13 +1394,35 @@ out:
 	dup2(pipefd[1], 2);
 
 	/* Run the program */
-	execl("/bin/sh", "sh", "-c", cmdline, NULL);
+	execv("/bin/sh", argv);
 
 	/* Happens only in case of error */
+	free(argv);
+	free(cmdline);
 	SMSD_LogErrno(Config, "Error executing new process");
 	exit(127);
 }
 #endif
+
+/**
+ * Executes an external command with one optional argument.
+ */
+static gboolean SMSD_RunOnSingle(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const char *argument, const char *event)
+{
+	GSM_StringArray arguments;
+	gboolean result;
+
+	GSM_StringArray_New(&arguments);
+	if (argument != NULL && !GSM_StringArray_Add(&arguments, argument)) {
+		SMSD_Log(DEBUG_ERROR, Config, "Failed to allocate run on %s argument", event);
+		GSM_StringArray_Free(&arguments);
+		return FALSE;
+	}
+
+	result = SMSD_RunOn(command, sms, Config, &arguments, event);
+	GSM_StringArray_Free(&arguments);
+	return result;
+}
 
 /**
  * Checks whether we are allowed to accept a message from number.
@@ -1387,18 +1504,19 @@ gboolean SMSD_ValidMessage(GSM_SMSDConfig *Config, GSM_MultiSMSMessage *sms)
 GSM_Error SMSD_ProcessSMS(GSM_SMSDConfig *Config, GSM_MultiSMSMessage *sms)
 {
 	GSM_Error error = ERR_NONE;
-	char *locations = NULL;
+	GSM_StringArray locations;
 
+	GSM_StringArray_New(&locations);
 	/* Increase message counter */
 	Config->Status->Received += sms->Number;
 	/* Send message to the backend */
 	error = Config->Service->SaveInboxSMS(sms, Config, &locations);
 	/* RunOnReceive handling */
 	if (Config->RunOnReceive != NULL && error == ERR_NONE) {
-		SMSD_RunOn(Config->RunOnReceive, sms, Config, locations, "receive");
+		SMSD_RunOn(Config->RunOnReceive, sms, Config, &locations, "receive");
 	}
 	/* Free memory allocated by SaveInboxSMS */
-	free(locations);
+	GSM_StringArray_Free(&locations);
 	return error;
 }
 
@@ -1858,7 +1976,7 @@ GSM_Error SMSD_SendSMS(GSM_SMSDConfig *Config)
 	}
 
 	if (Config->RunOnSent != NULL && error == ERR_NONE) {
-		SMSD_RunOn(Config->RunOnSent, &sms, Config, Config->SMSID, "sent");
+		SMSD_RunOnSingle(Config->RunOnSent, &sms, Config, Config->SMSID, "sent");
 	}
 
 	return ERR_NONE;
@@ -1871,7 +1989,7 @@ failure_unsent:
 	 * Consider checking with your modem manufacturer for proper error code handling.
 	 */
 	if (Config->RunOnFailure != NULL) {
-		SMSD_RunOn(Config->RunOnFailure, NULL, Config, Config->SMSID, "failure");
+		SMSD_RunOnSingle(Config->RunOnFailure, NULL, Config, Config->SMSID, "failure");
 	}
 	Config->Status->Failed++;
 
@@ -2018,7 +2136,7 @@ void SMSD_IncomingCallCallback(GSM_StateMachine *s, GSM_Call *call, void *user_d
 			}
 
 			if (Config->RunOnIncomingCall != NULL) {
-				SMSD_RunOn(Config->RunOnIncomingCall, NULL, Config, DecodeUnicodeString(call->PhoneNumber), "incoming call");
+				SMSD_RunOnSingle(Config->RunOnIncomingCall, NULL, Config, DecodeUnicodeString(call->PhoneNumber), "incoming call");
 			}
 		}
 		break;
@@ -2246,7 +2364,7 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 			error = GSM_InitConnection_Log(Config->gsm, 2, SMSD_Log_Function, Config);
 			/* run on error */
 			if (error != ERR_NONE && Config->RunOnFailure != NULL) {
-				SMSD_RunOn(Config->RunOnFailure, NULL, Config, "INIT", "failure");
+				SMSD_RunOnSingle(Config->RunOnFailure, NULL, Config, "INIT", "failure");
 			}
 			switch (error) {
 			case ERR_NONE:
@@ -2279,7 +2397,7 @@ GSM_Error SMSD_MainLoop(GSM_SMSDConfig *Config, gboolean exit_on_failure, int ma
 						error = Config->Service->InitAfterConnect(Config);
 						if (error!=ERR_NONE) {
 							if (Config->RunOnFailure != NULL) {
-								SMSD_RunOn(Config->RunOnFailure, NULL, Config, "INIT", "failure");
+								SMSD_RunOnSingle(Config->RunOnFailure, NULL, Config, "INIT", "failure");
 							}
 							SMSD_Terminate(Config, "Post initialisation failed, stopping Gammu smsd", error, TRUE, -1);
 							goto done_connected;

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -44,7 +44,7 @@ typedef struct {
 	GSM_Error	(*Init) 	      (GSM_SMSDConfig *Config);
 	GSM_Error	(*Free) 	      (GSM_SMSDConfig *Config);
 	GSM_Error	(*InitAfterConnect)   (GSM_SMSDConfig *Config);
-	GSM_Error	(*SaveInboxSMS)       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char **Locations);
+	GSM_Error	(*SaveInboxSMS)       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations);
 	GSM_Error	(*FindOutboxSMS)      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID);
 	GSM_Error	(*MoveSMS)  	      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, gboolean alwaysDelete, gboolean sent);
 	GSM_Error	(*CreateOutboxSMS)    (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *NewID);

--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -8,7 +8,6 @@
 #include <errno.h>
 #include <time.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -71,18 +70,17 @@ static void SMSDFiles_DecodeNumber(char *string)
 }
 
 /* Save SMS from phone (called Inbox sms - it's in phone Inbox) somewhere */
-static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, char **Locations)
+static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations)
 {
 	GSM_Error error = ERR_NONE;
 	int i, j;
-	unsigned char FileName[PATH_MAX], FullName[PATH_MAX], ext[4], buffer[64], buffer2[400];
+	char FileName[PATH_MAX];
+	unsigned char FullName[PATH_MAX], ext[4], buffer[64], buffer2[400];
 	gboolean done;
 	FILE *file;
-	size_t locations_size = 0, locations_pos = 0;
 #ifdef GSM_ENABLE_BACKUP
 	GSM_SMS_Backup *backup;
 #endif
-	*Locations = NULL;
 
 	j = 0;
 	done = FALSE;
@@ -123,17 +121,9 @@ static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfi
 			SMSD_Log(DEBUG_NOTICE, Config, "Delivery report: %s to %s, message reference 0x%02x",
 				 DecodeUnicodeString(sms->SMS[i].Text), buffer, sms->SMS[i].MessageReference);
 		} else {
-			if (locations_pos + strlen(FileName) + 2 >= locations_size) {
-				locations_size += strlen(FileName) + 30;
-				*Locations = (char *)realloc(*Locations, locations_size);
-				assert(*Locations != NULL);
-				if (locations_pos == 0) {
-					*Locations[0] = 0;
-				}
+			if (!GSM_StringArray_Add(Locations, FileName)) {
+				return ERR_MOREMEMORY;
 			}
-			strcat(*Locations, FileName);
-			strcat(*Locations, " ");
-			locations_pos += strlen(FileName) + 1;
 
 			if (strcasecmp(Config->inboxformat, "detail") == 0) {
 #ifndef GSM_ENABLE_BACKUP

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -22,7 +22,6 @@
 #include <stdio.h>
 #include <errno.h>
 #include <time.h>
-#include <assert.h>
 #ifdef WIN32
 #include <windows.h>
 #endif
@@ -702,7 +701,7 @@ static GSM_Error SMSDSQL_InitAfterConnect(GSM_SMSDConfig * Config)
 }
 
 /* Save SMS from phone (called Inbox sms - it's in phone Inbox) somewhere */
-static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, char **Locations)
+static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations)
 {
 	SQL_result res, res2;
 	SQL_Var vars[3];
@@ -718,10 +717,9 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 	gboolean found;
 	long diff;
 	unsigned long long new_id;
-	size_t locations_size = 0, locations_pos = 0;
 	const char *state, *smsc;
+	char location[50];
 
-	*Locations = NULL;
 	sms->Processed = FALSE;
 
 	for (i = 0; i < sms->Number; i++) {
@@ -826,20 +824,15 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 			SMSD_Log(DEBUG_INFO, Config, "Failed to get inserted row ID (%s)", __FUNCTION__);
 			return ERR_UNKNOWN;
 		}
-		SMSD_Log(DEBUG_NOTICE, Config, "Inserted message id %lu", (long)new_id);
+		SMSD_Log(DEBUG_NOTICE, Config, "Inserted message id %llu", new_id);
 
 		db->FreeResult(Config, &res);
 
 		if (new_id != 0) {
-			if (locations_pos + 10 >= locations_size) {
-				locations_size += 40;
-				*Locations = (char *)realloc(*Locations, locations_size);
-				assert(*Locations != NULL);
-				if (locations_pos == 0) {
-					*Locations[0] = 0;
-				}
+			snprintf(location, sizeof(location), "%llu", new_id);
+			if (!GSM_StringArray_Add(Locations, location)) {
+				return ERR_MOREMEMORY;
 			}
-			locations_pos += sprintf((*Locations) + locations_pos, "%lu ", (long)new_id);
 		}
 
 		error = SMSDSQL_NamedQuery(Config, Config->SMSDSQL_queries[SQL_QUERY_UPDATE_RECEIVED], &sms->SMS[i], sms, NULL, &res2, FALSE);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1214,6 +1214,23 @@ add_coverage(smsd-exit-on-failure)
 target_link_libraries(smsd-exit-on-failure libGammu ${LIBINTL_LIBRARIES} gsmsd)
 add_test(smsd-exit-on-failure "${GAMMU_TEST_PATH}/smsd-exit-on-failure${CMAKE_EXECUTABLE_SUFFIX}")
 
+add_executable(smsd-run-command smsd-run-command.c)
+add_coverage(smsd-run-command)
+target_link_libraries(smsd-run-command libGammu ${LIBINTL_LIBRARIES} gsmsd)
+add_test(smsd-run-command "${GAMMU_TEST_PATH}/smsd-run-command${CMAKE_EXECUTABLE_SUFFIX}")
+
+if (NOT WIN32)
+    add_executable(smsd-run-helper smsd-run-helper.c)
+    add_coverage(smsd-run-helper)
+    add_executable(smsd-run smsd-run.c)
+    add_coverage(smsd-run)
+    target_link_libraries(smsd-run libGammu ${LIBINTL_LIBRARIES} gsmsd)
+    add_test(smsd-run
+        "${GAMMU_TEST_PATH}/smsd-run${CMAKE_EXECUTABLE_SUFFIX}"
+        "${GAMMU_TEST_PATH}/smsd-run-helper${CMAKE_EXECUTABLE_SUFFIX}"
+        "${CMAKE_CURRENT_BINARY_DIR}/smsd-run-injected")
+endif (NOT WIN32)
+
 # Test for header gammu-statemachine.h
 add_executable(include-statemachine include-statemachine.c)
 add_coverage(include-statemachine)

--- a/tests/sms-at-parse.c
+++ b/tests/sms-at-parse.c
@@ -14,7 +14,7 @@
 #include "common.h"
 
 extern GSM_Error ATGEN_ReplyGetSMSMessage(GSM_Protocol_Message *msg, GSM_StateMachine * s);
-extern void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const char *locations);
+extern void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config);
 
 #define BUFFER_SIZE 16384
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 		DisplayMultiSMSInfo(&sms, TRUE, TRUE, NULL, NULL);
 		printf("Parts: %d, count: %d, ID16: %d, ID8: %d\n", sms.SMS[0].UDH.AllParts, sms.Number, sms.SMS[0].UDH.ID16bit, sms.SMS[0].UDH.ID8bit);
 
-		SMSD_RunOnReceiveEnvironment(&sms, smsd, "1");
+		SMSD_RunOnReceiveEnvironment(&sms, smsd);
 	}
 
 	/* This is normally done by ATGEN_Terminate */

--- a/tests/smsd-run-command.c
+++ b/tests/smsd-run-command.c
@@ -1,0 +1,92 @@
+#include <gammu.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../libgammu/misc/array.h"
+
+extern char *SMSD_RunOnCommand(const char *command, const GSM_StringArray *arguments);
+
+static int check_command(const char *actual, const char *expected)
+{
+	if (strcmp(actual, expected) == 0) {
+		return 0;
+	}
+
+	fprintf(stderr, "Command mismatch:\nexpected: %s\nactual: %s\n", expected, actual);
+	return 1;
+}
+
+int main(void)
+{
+	GSM_StringArray arguments;
+	char *command;
+	int result = 0;
+
+	GSM_StringArray_New(&arguments);
+
+	command = SMSD_RunOnCommand("command", &arguments);
+	result = check_command(command, "command");
+	free(command);
+	if (result != 0) {
+		return result;
+	}
+
+	if (!GSM_StringArray_Add(&arguments, "plain") ||
+	    !GSM_StringArray_Add(&arguments, "space value") ||
+	    !GSM_StringArray_Add(&arguments, "trail\\")) {
+		fprintf(stderr, "Failed to allocate test arguments\n");
+		GSM_StringArray_Free(&arguments);
+		return 1;
+	}
+
+	command = SMSD_RunOnCommand("command", &arguments);
+#ifdef WIN32
+	result = check_command(command, "command \"plain\" \"space value\" \"trail\\\\\"");
+#else
+	result = check_command(command, "command \"$@\"");
+#endif
+	free(command);
+	GSM_StringArray_Free(&arguments);
+
+#ifdef WIN32
+	{
+		const char *unsafe_arguments[] = {
+			"x\" & command",
+			"%",
+			"!",
+			"^",
+			"&",
+			"|",
+			"<",
+			">",
+			"(",
+			")",
+			"\n",
+			"\r",
+			"\t",
+			"\x7f",
+		};
+		size_t i;
+
+		for (i = 0; i < sizeof(unsafe_arguments) / sizeof(unsafe_arguments[0]); i++) {
+			GSM_StringArray_New(&arguments);
+			if (!GSM_StringArray_Add(&arguments, unsafe_arguments[i])) {
+				fprintf(stderr, "Failed to allocate unsafe test argument\n");
+				GSM_StringArray_Free(&arguments);
+				return 1;
+			}
+			command = SMSD_RunOnCommand("cmd.exe /c hook.bat", &arguments);
+			GSM_StringArray_Free(&arguments);
+			if (command != NULL) {
+				fprintf(stderr, "Unsafe Windows argument was accepted: %s\n", unsafe_arguments[i]);
+				free(command);
+				return 1;
+			}
+		}
+	}
+#endif
+
+	return result;
+}

--- a/tests/smsd-run-helper.c
+++ b/tests/smsd-run-helper.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int check_argument(const char *actual, const char *expected)
+{
+	if (strcmp(actual, expected) == 0) {
+		return 0;
+	}
+
+	fprintf(stderr, "Argument mismatch:\nexpected: %s\nactual: %s\n", expected, actual);
+	return 1;
+}
+
+int main(int argc, char **argv)
+{
+	const char *marker;
+	char expected[4096];
+
+	if (getenv("SMSD_TEST_EMPTY") != NULL) {
+		if (argc != 1) {
+			fprintf(stderr, "Expected no arguments, got %d\n", argc - 1);
+			return 1;
+		}
+		return 0;
+	}
+
+	if (getenv("SMSD_TEST_SINGLE") != NULL) {
+		if (argc != 2) {
+			fprintf(stderr, "Expected one argument, got %d\n", argc - 1);
+			return 1;
+		}
+		return check_argument(argv[1], "single argument");
+	}
+
+	marker = getenv("SMSD_TEST_MARKER");
+	if (marker == NULL) {
+		fprintf(stderr, "SMSD_TEST_MARKER is not set\n");
+		return 1;
+	}
+	if (argc != 12) {
+		fprintf(stderr, "Expected 11 arguments, got %d\n", argc - 1);
+		return 1;
+	}
+
+	if (check_argument(argv[1], "normal") != 0) return 1;
+
+	snprintf(expected, sizeof(expected), "$(touch %s)", marker);
+	if (check_argument(argv[2], expected) != 0) return 1;
+
+	snprintf(expected, sizeof(expected), "`touch %s`", marker);
+	if (check_argument(argv[3], expected) != 0) return 1;
+
+	snprintf(expected, sizeof(expected), "; touch %s", marker);
+	if (check_argument(argv[4], expected) != 0) return 1;
+
+	snprintf(expected, sizeof(expected), "& touch %s", marker);
+	if (check_argument(argv[5], expected) != 0) return 1;
+
+	snprintf(expected, sizeof(expected), "(touch %s)", marker);
+	if (check_argument(argv[6], expected) != 0) return 1;
+
+	if (check_argument(argv[7], "value with spaces\tand a tab") != 0) return 1;
+	if (check_argument(argv[8], "line one\nline two") != 0) return 1;
+	if (check_argument(argv[9], "$PATH") != 0) return 1;
+	if (check_argument(argv[10], "\"'") != 0) return 1;
+	if (check_argument(argv[11], "") != 0) return 1;
+
+	return 0;
+}

--- a/tests/smsd-run.c
+++ b/tests/smsd-run.c
@@ -1,0 +1,116 @@
+#include <gammu.h>
+#include <gammu-smsd.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../libgammu/misc/array.h"
+
+extern gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event);
+
+static gboolean add_argument(GSM_StringArray *arguments, const char *value)
+{
+	if (GSM_StringArray_Add(arguments, value)) {
+		return TRUE;
+	}
+
+	fprintf(stderr, "Failed to allocate test argument\n");
+	return FALSE;
+}
+
+static gboolean add_marker_argument(GSM_StringArray *arguments, const char *format, const char *marker)
+{
+	char value[4096];
+
+	snprintf(value, sizeof(value), format, marker);
+	return add_argument(arguments, value);
+}
+
+int main(int argc, char **argv)
+{
+	GSM_SMSDConfig *config;
+	GSM_StringArray arguments;
+	FILE *file;
+	gboolean result;
+
+	if (argc != 3) {
+		fprintf(stderr, "Usage: %s HELPER MARKER\n", argv[0]);
+		return 1;
+	}
+
+	remove(argv[2]);
+	setenv("SMSD_RUN_HELPER", argv[1], 1);
+	setenv("SMSD_TEST_MARKER", argv[2], 1);
+	unsetenv("SMSD_TEST_EMPTY");
+	unsetenv("SMSD_TEST_SINGLE");
+
+	config = SMSD_NewConfig("test");
+	if (config == NULL) {
+		fprintf(stderr, "Failed to allocate SMSD config\n");
+		return 1;
+	}
+
+	GSM_StringArray_New(&arguments);
+	if (!add_argument(&arguments, "normal") ||
+	    !add_marker_argument(&arguments, "$(touch %s)", argv[2]) ||
+	    !add_marker_argument(&arguments, "`touch %s`", argv[2]) ||
+	    !add_marker_argument(&arguments, "; touch %s", argv[2]) ||
+	    !add_marker_argument(&arguments, "& touch %s", argv[2]) ||
+	    !add_marker_argument(&arguments, "(touch %s)", argv[2]) ||
+	    !add_argument(&arguments, "value with spaces\tand a tab") ||
+	    !add_argument(&arguments, "line one\nline two") ||
+	    !add_argument(&arguments, "$PATH") ||
+	    !add_argument(&arguments, "\"'") ||
+	    !add_argument(&arguments, "")) {
+		GSM_StringArray_Free(&arguments);
+		SMSD_FreeConfig(config);
+		return 1;
+	}
+
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	GSM_StringArray_Free(&arguments);
+	if (!result) {
+		fprintf(stderr, "RunOn command failed\n");
+		SMSD_FreeConfig(config);
+		return 1;
+	}
+
+	file = fopen(argv[2], "r");
+	if (file != NULL) {
+		fclose(file);
+		fprintf(stderr, "Injected command created marker file\n");
+		remove(argv[2]);
+		SMSD_FreeConfig(config);
+		return 1;
+	}
+
+	GSM_StringArray_New(&arguments);
+	setenv("SMSD_TEST_EMPTY", "1", 1);
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	GSM_StringArray_Free(&arguments);
+	unsetenv("SMSD_TEST_EMPTY");
+	if (!result) {
+		fprintf(stderr, "RunOn command without arguments failed\n");
+		SMSD_FreeConfig(config);
+		return 1;
+	}
+
+	GSM_StringArray_New(&arguments);
+	setenv("SMSD_TEST_SINGLE", "1", 1);
+	if (!add_argument(&arguments, "single argument")) {
+		GSM_StringArray_Free(&arguments);
+		SMSD_FreeConfig(config);
+		return 1;
+	}
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	GSM_StringArray_Free(&arguments);
+	unsetenv("SMSD_TEST_SINGLE");
+	SMSD_FreeConfig(config);
+
+	if (!result) {
+		fprintf(stderr, "RunOn command with one argument failed\n");
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Keep caller-controlled message identifiers out of shell command text so crafted sender values cannot execute commands. Reject cmd.exe-sensitive Windows arguments and preserve literal argument boundaries across backends.