### PR TITLE
fix(smsd): make ODBC result reads portable

### DIFF
--- a/smsd/services/odbc.c
+++ b/smsd/services/odbc.c
@@ -125,25 +125,19 @@ const char *SMSDODBC_GetString(GSM_SMSDConfig * Config, SQL_result *res, unsigne
 
 gboolean SMSDODBC_GetBool(GSM_SMSDConfig * Config, SQL_result *res, unsigned int field)
 {
-	long long intval = 0;
-	const char * charval;
+	const char *value;
 
-	/* Try bit field */
-	if (SQL_SUCCEEDED(SQLGetData(res->odbc, field + 1, SQL_C_BIT, &intval, 0, NULL))) {
-		SMSD_Log(DEBUG_SQL, Config, "Field %d returning bit \"%lld\"", field, intval);
-		return intval ? TRUE : FALSE;
+	/*
+	 * Fetch booleans as text so both native bit columns ("0"/"1") and
+	 * textual SQL enums ("false"/"true", "no"/"yes") are interpreted
+	 * consistently. Some ODBC drivers successfully convert textual values
+	 * to SQL_C_BIT as zero, making a type-conversion fallback unreliable.
+	 */
+	value = SMSDODBC_GetString(Config, res, field);
+	if (value == NULL) {
+		return FALSE;
 	}
-
-	/* Try to get numeric value first */
-	intval = SMSDODBC_GetNumber(Config, res, field);
-	if (intval == -1) {
-		/* If that fails, fall back to string and parse it */
-		charval = SMSDODBC_GetString(Config, res, field);
-		SMSD_Log(DEBUG_SQL, Config, "Field %d returning string \"%s\"", field, charval);
-		return GSM_StringToBool(charval);
-	}
-	SMSD_Log(DEBUG_SQL, Config, "Field %d returning integer \"%lld\"", field, intval);
-	return intval ? TRUE : FALSE;
+	return GSM_StringToBool(value);
 }
 
 /* Disconnects from a database */

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -716,7 +716,7 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 	time_t t_time1, t_time2;
 	gboolean found;
 	long diff;
-	unsigned long long new_id;
+	unsigned long long new_id, sent_id;
 	const char *state, *smsc;
 	char location[50];
 
@@ -737,7 +737,9 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 
 			found = FALSE;
 			while (db->NextRow(Config, &res)) {
+				sent_id = db->GetNumber(Config, &res, 0);
 				state = db->GetString(Config, &res, 1);
+				t_time1 = db->GetDate(Config, &res, 2);
 				smsc = db->GetString(Config, &res, 4);
 				SMSD_Log(DEBUG_NOTICE, Config, "Checking for delivery report, SMSC=%s, state=%s", smsc, state);
 
@@ -749,7 +751,6 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 				}
 
 				if (strcmp(state, "SendingOK") == 0 || strcmp(state, "DeliveryPending") == 0) {
-					t_time1 = db->GetDate(Config, &res, 2);
 					if (t_time1 < 0) {
 						SMSD_Log(DEBUG_ERROR, Config, "Invalid SendingDateTime -1 for SMS TPMR=%i", sms->SMS[i].MessageReference);
 						return ERR_UNKNOWN;
@@ -789,7 +790,7 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 				vars[0].type = SQL_TYPE_STRING;
 				vars[0].v.s = status;			/* Status */
 				vars[1].type = SQL_TYPE_INT;
-				vars[1].v.i = (long)db->GetNumber(Config, &res, 0); /* ID */
+				vars[1].v.i = (long)sent_id; /* ID */
 				vars[2].type = SQL_TYPE_NONE;
 
 				error = SMSDSQL_NamedQuery(Config, q, &sms->SMS[i], sms, vars, &res2, FALSE);
@@ -999,14 +1000,6 @@ static GSM_Error SMSDSQL_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig
 			return ERR_NONE;
 		}
 
-		status = db->GetString(Config, &res, i == 1 ? 12 : 7);
-		if (status != NULL && strncmp(status, "SendingOK", 9) == 0) {
-			SMSD_Log(DEBUG_NOTICE, Config, "Marking %s:%d message for skip", ID, i);
-			Config->SkipMessage[sms->Number] = TRUE;
-		} else {
-			Config->SkipMessage[sms->Number] = FALSE;
-		}
-
 		text = db->GetString(Config, &res, 0);
 		coding = db->GetString(Config, &res, 1);
 		if (text == NULL) {
@@ -1091,7 +1084,6 @@ static GSM_Error SMSDSQL_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig
 		}
 
 		sms->SMS[sms->Number].PDU = SMS_Submit;
-		sms->Number++;
 
 		if (i == 1) {
 			/* Is this a multipart message? */
@@ -1103,6 +1095,16 @@ static GSM_Error SMSDSQL_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig
 			Config->CreatorID[sizeof(Config->CreatorID) - 1] = 0;
 			Config->retries = (int)db->GetNumber(Config, &res, 11);
 		}
+
+		status = db->GetString(Config, &res, i == 1 ? 12 : 7);
+		if (status != NULL && strncmp(status, "SendingOK", 9) == 0) {
+			SMSD_Log(DEBUG_NOTICE, Config, "Marking %s:%d message for skip", ID, i);
+			Config->SkipMessage[sms->Number] = TRUE;
+		} else {
+			Config->SkipMessage[sms->Number] = FALSE;
+		}
+
+		sms->Number++;
 		db->FreeResult(Config, &res);
 		if (last) {
 			last = FALSE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,8 +56,8 @@ add_coverage(utf-8)
 target_link_libraries (utf-8 libGammu)
 add_test(utf-8 "${GAMMU_TEST_PATH}/utf-8${CMAKE_EXECUTABLE_SUFFIX}")
 
-# SQL backend date parsing
-if (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H)
+# SQL backend tests
+if (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H OR ODBC_FOUND)
     if (LIBDBI_FOUND)
         include_directories (${LIBDBI_INCLUDE_DIR})
     endif (LIBDBI_FOUND)
@@ -70,11 +70,20 @@ if (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H)
         include_directories (${POSTGRES_INCLUDE_DIR})
     endif (POSTGRES_FOUND)
 
+    if (ODBC_FOUND)
+        include_directories (${ODBC_INCLUDE_DIR})
+    endif (ODBC_FOUND)
+
     add_executable(sql-parse-date sql-parse-date.c)
     add_coverage(sql-parse-date)
     target_link_libraries (sql-parse-date gsmsd)
     add_test(sql-parse-date "${GAMMU_TEST_PATH}/sql-parse-date${CMAKE_EXECUTABLE_SUFFIX}")
-endif (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H)
+
+    add_executable(sql-read-order sql-read-order.c)
+    add_coverage(sql-read-order)
+    target_link_libraries (sql-read-order gsmsd)
+    add_test(sql-read-order "${GAMMU_TEST_PATH}/sql-read-order${CMAKE_EXECUTABLE_SUFFIX}")
+endif (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H OR ODBC_FOUND)
 
 # Backup comments
 if (WITH_BACKUP)

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -11,6 +11,10 @@ if(POSTGRES_INCLUDE_DIR)
     include_directories(${POSTGRES_INCLUDE_DIR})
 endif()
 
+if(ODBC_INCLUDE_DIR)
+    include_directories(${ODBC_INCLUDE_DIR})
+endif()
+
 MACRO(atgen_test TEST_NAME)
     add_executable(${TEST_NAME} ${TEST_NAME}.c)
     add_coverage(${TEST_NAME})

--- a/tests/sql-read-order.c
+++ b/tests/sql-read-order.c
@@ -1,0 +1,414 @@
+/**
+ * Tests that SQL service rows are read in ascending column order.
+ *
+ * Some ODBC drivers require SQLGetData calls to follow column order.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <gammu.h>
+#include <gammu-smsd.h>
+
+#include "../smsd/core.h"
+#include "../smsd/services/sql.h"
+#include "common.h"
+
+typedef enum {
+	RESULT_NONE,
+	RESULT_FIND_ID,
+	RESULT_REFRESH,
+	RESULT_OUTBOX_BODY,
+	RESULT_OUTBOX_MULTIPART,
+	RESULT_DELIVERY_SELECT,
+	RESULT_DELIVERY_UPDATE
+} ResultKind;
+
+typedef struct {
+	SQL_result *result;
+	ResultKind kind;
+	int row;
+	int last_field;
+	unsigned long long fields;
+} ResultState;
+
+static ResultState states[4];
+static unsigned long long find_id_fields;
+static unsigned long long outbox_body_fields;
+static unsigned long long outbox_multipart_fields;
+static unsigned long long delivery_fields;
+static int multipart_queries;
+static time_t delivery_time;
+static gboolean delivery_update_seen;
+static char query_find_id[] = "find-id";
+static char query_refresh[] = "refresh";
+static char query_outbox_body[] = "outbox-body";
+static char query_outbox_multipart[] = "outbox-multipart";
+static char query_delivery_select[] = "delivery-select";
+static char query_delivery_update[] = "delivery-update";
+static char query_delivery_update_other[] = "delivery-update-other";
+
+static ResultState *find_state(SQL_result *result)
+{
+	int i;
+
+	for (i = 0; i < 4; i++) {
+		if (states[i].result == result) {
+			return &states[i];
+		}
+	}
+	return NULL;
+}
+
+static ResultState *set_state(SQL_result *result, ResultKind kind)
+{
+	ResultState *state;
+	int i;
+
+	state = find_state(result);
+	if (state == NULL) {
+		for (i = 0; i < 4; i++) {
+			if (states[i].result == NULL) {
+				state = &states[i];
+				state->result = result;
+				break;
+			}
+		}
+	}
+	test_result(state != NULL);
+
+	state->kind = kind;
+	state->row = 0;
+	state->last_field = -1;
+	state->fields = 0;
+	return state;
+}
+
+static ResultState *record_field(SQL_result *result, unsigned int field)
+{
+	ResultState *state = find_state(result);
+
+	test_result(state != NULL);
+	test_result((int)field >= state->last_field);
+	state->last_field = (int)field;
+	state->fields |= 1ULL << field;
+	return state;
+}
+
+static GSM_Error mock_connect(GSM_SMSDConfig *config UNUSED)
+{
+	return ERR_NONE;
+}
+
+static GSM_Error mock_query(GSM_SMSDConfig *config UNUSED, const char *query, SQL_result *result)
+{
+	ResultKind kind;
+
+	if (strcmp(query, "find-id") == 0) {
+		kind = RESULT_FIND_ID;
+	} else if (strcmp(query, "refresh") == 0) {
+		kind = RESULT_REFRESH;
+	} else if (strcmp(query, "outbox-body") == 0) {
+		kind = RESULT_OUTBOX_BODY;
+	} else if (strcmp(query, "outbox-multipart") == 0) {
+		kind = RESULT_OUTBOX_MULTIPART;
+		multipart_queries++;
+	} else if (strcmp(query, "delivery-select") == 0) {
+		kind = RESULT_DELIVERY_SELECT;
+	} else if (strcmp(query, "delivery-update") == 0 || strcmp(query, "delivery-update-other") == 0) {
+		kind = RESULT_DELIVERY_UPDATE;
+		delivery_update_seen = TRUE;
+	} else {
+		fprintf(stderr, "Unexpected query: %s\n", query);
+		return ERR_BUG;
+	}
+
+	set_state(result, kind);
+	return ERR_NONE;
+}
+
+static void mock_free(GSM_SMSDConfig *config UNUSED)
+{
+}
+
+static void mock_free_result(GSM_SMSDConfig *config UNUSED, SQL_result *result)
+{
+	ResultState *state = find_state(result);
+
+	test_result(state != NULL);
+	switch (state->kind) {
+		case RESULT_FIND_ID:
+			find_id_fields = state->fields;
+			break;
+		case RESULT_OUTBOX_BODY:
+			outbox_body_fields = state->fields;
+			break;
+		case RESULT_OUTBOX_MULTIPART:
+			outbox_multipart_fields |= state->fields;
+			break;
+		case RESULT_DELIVERY_SELECT:
+			delivery_fields = state->fields;
+			break;
+		default:
+			break;
+	}
+	state->kind = RESULT_NONE;
+}
+
+static int mock_next_row(GSM_SMSDConfig *config UNUSED, SQL_result *result)
+{
+	ResultState *state = find_state(result);
+
+	test_result(state != NULL);
+	switch (state->kind) {
+		case RESULT_FIND_ID:
+		case RESULT_OUTBOX_BODY:
+		case RESULT_DELIVERY_SELECT:
+			return state->row++ == 0;
+		case RESULT_OUTBOX_MULTIPART:
+			return multipart_queries == 1 && state->row++ == 0;
+		default:
+			return 0;
+	}
+}
+
+static unsigned long long mock_seq_id(GSM_SMSDConfig *config UNUSED, const char *id UNUSED)
+{
+	return 0;
+}
+
+static unsigned long mock_affected_rows(GSM_SMSDConfig *config UNUSED, SQL_result *result)
+{
+	ResultState *state = find_state(result);
+
+	test_result(state != NULL);
+	return state->kind == RESULT_REFRESH ? 1 : 0;
+}
+
+static const char *mock_get_string(GSM_SMSDConfig *config UNUSED, SQL_result *result, unsigned int field)
+{
+	ResultState *state = record_field(result, field);
+
+	if (state->kind == RESULT_OUTBOX_BODY) {
+		switch (field) {
+			case 0:
+			case 2:
+				return NULL;
+			case 1:
+				return "Default_No_Compression";
+			case 4:
+				return "test message";
+			case 6:
+				return "+420123456";
+			case 10:
+				return "sql-read-order";
+			case 12:
+				return "SendingOK";
+			default:
+				break;
+		}
+	} else if (state->kind == RESULT_OUTBOX_MULTIPART) {
+		switch (field) {
+			case 0:
+			case 2:
+				return NULL;
+			case 1:
+				return "Default_No_Compression";
+			case 4:
+				return "multipart message";
+			case 7:
+				return "SendingOK";
+			default:
+				break;
+		}
+	} else if (state->kind == RESULT_DELIVERY_SELECT) {
+		if (field == 1) {
+			return "SendingOK";
+		}
+		if (field == 4) {
+			return "+420987654";
+		}
+	}
+
+	fprintf(stderr, "Unexpected string field %u for result kind %d\n", field, state->kind);
+	exit(2);
+}
+
+static long long mock_get_number(GSM_SMSDConfig *config UNUSED, SQL_result *result, unsigned int field)
+{
+	ResultState *state = record_field(result, field);
+
+	if (state->kind == RESULT_FIND_ID && field == 0) {
+		return 42;
+	}
+	if (state->kind == RESULT_OUTBOX_BODY) {
+		switch (field) {
+			case 3:
+				return -1;
+			case 5:
+				return 42;
+			case 8:
+				return SMS_VALID_Max_Time;
+			case 11:
+				return 0;
+			default:
+				break;
+		}
+	}
+	if (state->kind == RESULT_OUTBOX_MULTIPART) {
+		switch (field) {
+			case 3:
+				return -1;
+			case 5:
+				return 42;
+			default:
+				break;
+		}
+	}
+	if (state->kind == RESULT_DELIVERY_SELECT && field == 0) {
+		return 123;
+	}
+
+	fprintf(stderr, "Unexpected numeric field %u for result kind %d\n", field, state->kind);
+	exit(2);
+}
+
+static time_t mock_get_date(GSM_SMSDConfig *config UNUSED, SQL_result *result, unsigned int field)
+{
+	ResultState *state = record_field(result, field);
+
+	if (state->kind == RESULT_FIND_ID && field == 1) {
+		return time(NULL);
+	}
+	if (state->kind == RESULT_DELIVERY_SELECT && field == 2) {
+		return delivery_time;
+	}
+
+	fprintf(stderr, "Unexpected date field %u for result kind %d\n", field, state->kind);
+	exit(2);
+}
+
+static gboolean mock_get_bool(GSM_SMSDConfig *config UNUSED, SQL_result *result, unsigned int field)
+{
+	ResultState *state = record_field(result, field);
+
+	if (state->kind == RESULT_OUTBOX_BODY && field == 7) {
+		return TRUE;
+	}
+	if (state->kind == RESULT_OUTBOX_BODY && field == 9) {
+		return TRUE;
+	}
+
+	fprintf(stderr, "Unexpected boolean field %u for result kind %d\n", field, state->kind);
+	exit(2);
+}
+
+static char *mock_quote_string(GSM_SMSDConfig *config UNUSED, const char *value)
+{
+	char *result = malloc(strlen(value) + 1);
+
+	test_result(result != NULL);
+	strcpy(result, value);
+	return result;
+}
+
+static struct GSM_SMSDdbobj mock_db = {
+	mock_connect,
+	mock_query,
+	mock_free,
+	mock_free_result,
+	mock_next_row,
+	mock_seq_id,
+	mock_affected_rows,
+	mock_get_string,
+	mock_get_number,
+	mock_get_date,
+	mock_get_bool,
+	mock_quote_string
+};
+
+static void reset_mock(void)
+{
+	memset(states, 0, sizeof(states));
+	find_id_fields = 0;
+	outbox_body_fields = 0;
+	outbox_multipart_fields = 0;
+	delivery_fields = 0;
+	multipart_queries = 0;
+	delivery_update_seen = FALSE;
+}
+
+static void setup_config(GSM_SMSDConfig *config)
+{
+	memset(config, 0, sizeof(*config));
+	config->driver = "odbc";
+	config->sql = "mysql";
+	config->db = &mock_db;
+	config->backend_retries = 1;
+	config->skipsmscnumber = "";
+	config->deliveryreportdelay = 3600;
+
+	config->SMSDSQL_queries[SQL_QUERY_FIND_OUTBOX_SMS_ID] = query_find_id;
+	config->SMSDSQL_queries[SQL_QUERY_REFRESH_SEND_STATUS] = query_refresh;
+	config->SMSDSQL_queries[SQL_QUERY_FIND_OUTBOX_BODY] = query_outbox_body;
+	config->SMSDSQL_queries[SQL_QUERY_FIND_OUTBOX_MULTIPART] = query_outbox_multipart;
+	config->SMSDSQL_queries[SQL_QUERY_SAVE_INBOX_SMS_SELECT] = query_delivery_select;
+	config->SMSDSQL_queries[SQL_QUERY_SAVE_INBOX_SMS_UPDATE_DELIVERED] = query_delivery_update;
+	config->SMSDSQL_queries[SQL_QUERY_SAVE_INBOX_SMS_UPDATE] = query_delivery_update_other;
+}
+
+static void test_find_outbox_order(void)
+{
+	GSM_SMSDConfig config;
+	GSM_MultiSMSMessage sms;
+	GSM_Error error;
+	char id[32];
+
+	reset_mock();
+	setup_config(&config);
+	memset(&sms, 0, sizeof(sms));
+
+	error = SMSDSQL.FindOutboxSMS(&sms, &config, id);
+
+	test_result(error == ERR_NONE);
+	test_result(strcmp(id, "42") == 0);
+	test_result(sms.Number == 2);
+	test_result(config.SkipMessage[0] == TRUE);
+	test_result(config.SkipMessage[1] == TRUE);
+	test_result(find_id_fields == ((1ULL << 0) | (1ULL << 1)));
+	test_result(outbox_body_fields == ((1ULL << 13) - 1));
+	test_result(outbox_multipart_fields == (((1ULL << 6) - 1) | (1ULL << 7)));
+}
+
+static void test_delivery_report_order(void)
+{
+	GSM_SMSDConfig config;
+	GSM_MultiSMSMessage sms;
+	GSM_Error error;
+
+	reset_mock();
+	setup_config(&config);
+	memset(&sms, 0, sizeof(sms));
+	sms.Number = 1;
+	GSM_SetDefaultSMSData(&sms.SMS[0]);
+	sms.SMS[0].PDU = SMS_Status_Report;
+	EncodeUnicode(sms.SMS[0].Number, "+420123456", strlen("+420123456"));
+	EncodeUnicode(sms.SMS[0].SMSC.Number, "+420987654", strlen("+420987654"));
+	EncodeUnicode(sms.SMS[0].Text, "Delivered", strlen("Delivered"));
+	delivery_time = Fill_Time_T(sms.SMS[0].DateTime);
+
+	error = SMSDSQL.SaveInboxSMS(&sms, &config, NULL);
+
+	test_result(error == ERR_NONE);
+	test_result(delivery_update_seen == TRUE);
+	test_result(delivery_fields == ((1ULL << 0) | (1ULL << 1) | (1ULL << 2) | (1ULL << 4)));
+}
+
+int main(void)
+{
+	test_find_outbox_order();
+	test_delivery_report_order();
+	return 0;
+}


### PR DESCRIPTION
Some ODBC drivers reject out-of-order SQLGetData calls and coerce textual boolean enums to zero. Read selected columns in ascending order and parse booleans from their string form, with regression coverage.

Fixes #252
Fixes #312
Fixes #501
Fixes #553