### PR TITLE
test(smsd): cover SQL Server through ODBC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,59 @@ jobs:
     - name: coverage
       run: make -C _build gcov
     - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+  mssql-odbc:
+    runs-on: ubuntu-24.04
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
+      MSSQL_SA_PASSWORD: GammuODBC2026
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-CU26-ubuntu-22.04@sha256:ba4c8329f48fb8f02e1416be6a930ebfd71268caee78aa985f3af4315e457c89
+        env:
+          ACCEPT_EULA: Y
+          MSSQL_PID: Developer
+          MSSQL_SA_PASSWORD: GammuODBC2026
+        options: >-
+          --health-cmd="/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P GammuODBC2026 -Q 'SELECT 1'"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-start-period=20s
+          --health-retries=12
+        ports:
+        - 1433:1433
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+    - name: Install Microsoft ODBC tools
+      run: |
+        curl -sSL -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/24.04/packages-microsoft-prod.deb
+        sudo dpkg -i /tmp/packages-microsoft-prod.deb
+        sudo apt-get update
+        sudo ACCEPT_EULA=Y apt-get install -y cmake cmake-data msodbcsql18 mssql-tools18 unixodbc-dev
+    - name: Configure ODBC
+      run: |
+        sudo tee /etc/odbc.ini >/dev/null <<'EOF'
+        [smsd-mssql]
+        Driver = ODBC Driver 18 for SQL Server
+        Server = tcp:127.0.0.1,1433
+        Database = smsd
+        Encrypt = yes
+        TrustServerCertificate = yes
+        EOF
+    - name: Create database
+      run: |
+        /opt/mssql-tools18/bin/sqlcmd -C -b -S 127.0.0.1,1433 -U sa -P "$MSSQL_SA_PASSWORD" -Q "CREATE DATABASE smsd COLLATE Latin1_General_100_CI_AS_SC_UTF8"
+    - name: Configure and build
+      run: |
+        cmake -S . -B _build-mssql \
+          -DMSSQL_TESTING=ON \
+          -DMSSQL_HOST=127.0.0.1,1433 \
+          -DMSSQL_DATABASE=smsd \
+          -DMSSQL_USER=sa \
+          -DMSSQL_PASSWORD="$MSSQL_SA_PASSWORD" \
+          -DMSSQL_ODBC_DSN=smsd-mssql
+        cmake --build _build-mssql --parallel 2 --target gammu-smsd gammu-smsd-inject gammu-smsd-monitor
+    - name: Test ODBC with Microsoft SQL Server
+      run: ctest --test-dir _build-mssql --output-on-failure -R '^smsd-odbc-mssql$'
   windows:
     runs-on: windows-latest
     env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option (ONLINE_TESTING "Enable testing of parts which use remote servers" OFF)
 option (PSQL_TESTING "Enable testing of PostgreSQL SMSD backend" OFF)
 option (MYSQL_TESTING "Enable testing of MySQL SMSD backend" OFF)
 option (ODBC_TESTING "Enable testing of ODBC MySQL SMSD backend" OFF)
+option (MSSQL_TESTING "Enable testing of ODBC Microsoft SQL Server SMSD backend" OFF)
 option (BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 option (LARGE_FILES "Support for large files" ON)
@@ -173,6 +174,7 @@ else()
 find_program(MYSQL_BIN mysql)
 find_program(PSQL_BIN psql)
 endif()
+find_program(SQLCMD_BIN sqlcmd HINTS /opt/mssql-tools18/bin /opt/mssql-tools/bin)
 
 find_package (Threads)
 

--- a/docs/sql/mssql.sql
+++ b/docs/sql/mssql.sql
@@ -1,0 +1,199 @@
+--
+-- Database tables for Gammu SMSD on Microsoft SQL Server
+--
+-- Use a UTF-8 collation for the database because SMSD sends UTF-8 text
+-- through the ODBC narrow-character interface.
+--
+
+SET NOCOUNT ON;
+SET QUOTED_IDENTIFIER ON;
+
+DROP TABLE IF EXISTS sentitems;
+DROP TABLE IF EXISTS phones;
+DROP TABLE IF EXISTS outbox_multipart;
+DROP TABLE IF EXISTS outbox;
+DROP TABLE IF EXISTS inbox;
+DROP TABLE IF EXISTS gammu;
+GO
+
+CREATE TABLE gammu (
+  "Version" smallint NOT NULL DEFAULT 0 PRIMARY KEY
+);
+
+INSERT INTO gammu ("Version") VALUES (17);
+GO
+
+CREATE TABLE inbox (
+  "UpdatedInDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "ReceivingDateTime" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "Text" varchar(max) NOT NULL,
+  "SenderNumber" varchar(20) NOT NULL DEFAULT '',
+  "Coding" varchar(255) NOT NULL DEFAULT 'Default_No_Compression',
+  "UDH" varchar(max) NOT NULL,
+  "SMSCNumber" varchar(20) NOT NULL DEFAULT '',
+  "Class" integer NOT NULL DEFAULT -1,
+  "TextDecoded" varchar(max) NOT NULL DEFAULT '',
+  "ID" integer IDENTITY(1, 1) PRIMARY KEY,
+  "RecipientID" varchar(max) NOT NULL,
+  "Processed" bit NOT NULL DEFAULT 0,
+  "Status" integer NOT NULL DEFAULT -1,
+  CHECK ("Coding" IN
+    ('Default_No_Compression','Unicode_No_Compression','8bit','Default_Compression','Unicode_Compression'))
+);
+GO
+
+CREATE TRIGGER inbox_update_timestamp ON inbox AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  IF TRIGGER_NESTLEVEL() > 1 RETURN;
+  UPDATE target
+     SET "UpdatedInDB" = CURRENT_TIMESTAMP
+    FROM inbox AS target
+    JOIN inserted AS changed ON target."ID" = changed."ID";
+END;
+GO
+
+CREATE TABLE outbox (
+  "UpdatedInDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "InsertIntoDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "SendingDateTime" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "SendBefore" time(0) NOT NULL DEFAULT '23:59:59',
+  "SendAfter" time(0) NOT NULL DEFAULT '00:00:00',
+  "Text" varchar(max) NULL,
+  "DestinationNumber" varchar(20) NOT NULL DEFAULT '',
+  "Coding" varchar(255) NOT NULL DEFAULT 'Default_No_Compression',
+  "UDH" varchar(max) NULL,
+  "Class" integer DEFAULT -1,
+  "TextDecoded" varchar(max) NOT NULL DEFAULT '',
+  "ID" integer IDENTITY(1, 1) PRIMARY KEY,
+  "MultiPart" bit NOT NULL DEFAULT 0,
+  "RelativeValidity" integer DEFAULT -1,
+  "SenderID" varchar(255) NULL,
+  "SendingTimeOut" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "DeliveryReport" varchar(10) DEFAULT 'default',
+  "CreatorID" varchar(max) NOT NULL,
+  "Retries" integer DEFAULT 0,
+  "Priority" integer DEFAULT 0,
+  "Status" varchar(255) NOT NULL DEFAULT 'Reserved',
+  "StatusCode" integer NOT NULL DEFAULT -1,
+  CHECK ("Coding" IN
+    ('Default_No_Compression','Unicode_No_Compression','8bit','Default_Compression','Unicode_Compression')),
+  CHECK ("DeliveryReport" IN ('default','yes','no')),
+  CHECK ("Status" IN
+    ('SendingOK','SendingOKNoReport','SendingError','DeliveryOK','DeliveryFailed','DeliveryPending',
+     'DeliveryUnknown','Error','Reserved'))
+);
+
+CREATE INDEX outbox_date ON outbox("SendingDateTime", "SendingTimeOut");
+CREATE INDEX outbox_sender ON outbox("SenderID");
+GO
+
+CREATE TRIGGER outbox_update_timestamp ON outbox AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  IF TRIGGER_NESTLEVEL() > 1 RETURN;
+  UPDATE target
+     SET "UpdatedInDB" = CURRENT_TIMESTAMP
+    FROM outbox AS target
+    JOIN inserted AS changed ON target."ID" = changed."ID";
+END;
+GO
+
+CREATE TABLE outbox_multipart (
+  "Text" varchar(max) NULL,
+  "Coding" varchar(255) NOT NULL DEFAULT 'Default_No_Compression',
+  "UDH" varchar(max) NULL,
+  "Class" integer DEFAULT -1,
+  "TextDecoded" varchar(max) NULL,
+  "ID" integer NOT NULL DEFAULT 0,
+  "SequencePosition" integer NOT NULL DEFAULT 1,
+  "Status" varchar(255) NOT NULL DEFAULT 'Reserved',
+  "StatusCode" integer NOT NULL DEFAULT -1,
+  PRIMARY KEY ("ID", "SequencePosition"),
+  CHECK ("Coding" IN
+    ('Default_No_Compression','Unicode_No_Compression','8bit','Default_Compression','Unicode_Compression')),
+  CHECK ("Status" IN
+    ('SendingOK','SendingOKNoReport','SendingError','DeliveryOK','DeliveryFailed','DeliveryPending',
+     'DeliveryUnknown','Error','Reserved'))
+);
+GO
+
+CREATE TABLE phones (
+  "ID" varchar(max) NOT NULL,
+  "UpdatedInDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "InsertIntoDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "TimeOut" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "Send" varchar(3) NOT NULL DEFAULT 'no',
+  "Receive" varchar(3) NOT NULL DEFAULT 'no',
+  "IMEI" varchar(35) NOT NULL PRIMARY KEY,
+  "IMSI" varchar(35) NOT NULL,
+  "NetCode" varchar(10) DEFAULT 'ERROR',
+  "NetName" varchar(35) DEFAULT 'ERROR',
+  "Client" varchar(max) NOT NULL,
+  "Battery" integer NOT NULL DEFAULT -1,
+  "Signal" integer NOT NULL DEFAULT -1,
+  "Sent" integer NOT NULL DEFAULT 0,
+  "Received" integer NOT NULL DEFAULT 0,
+  CHECK ("Send" IN ('yes','no')),
+  CHECK ("Receive" IN ('yes','no'))
+);
+GO
+
+CREATE TRIGGER phones_update_timestamp ON phones AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  IF TRIGGER_NESTLEVEL() > 1 RETURN;
+  UPDATE target
+     SET "UpdatedInDB" = CURRENT_TIMESTAMP
+    FROM phones AS target
+    JOIN inserted AS changed ON target."IMEI" = changed."IMEI";
+END;
+GO
+
+CREATE TABLE sentitems (
+  "UpdatedInDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "InsertIntoDB" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "SendingDateTime" datetime2(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "DeliveryDateTime" datetime2(0) NULL,
+  "Text" varchar(max) NOT NULL,
+  "DestinationNumber" varchar(20) NOT NULL DEFAULT '',
+  "Coding" varchar(255) NOT NULL DEFAULT 'Default_No_Compression',
+  "UDH" varchar(max) NOT NULL,
+  "SMSCNumber" varchar(20) NOT NULL DEFAULT '',
+  "Class" integer NOT NULL DEFAULT -1,
+  "TextDecoded" varchar(max) NOT NULL DEFAULT '',
+  "ID" integer NOT NULL DEFAULT 0,
+  "SenderID" varchar(255) NOT NULL,
+  "SequencePosition" integer NOT NULL DEFAULT 1,
+  "Status" varchar(255) NOT NULL DEFAULT 'SendingOK',
+  "StatusError" integer NOT NULL DEFAULT -1,
+  "TPMR" integer NOT NULL DEFAULT -1,
+  "RelativeValidity" integer NOT NULL DEFAULT -1,
+  "CreatorID" varchar(max) NOT NULL,
+  "StatusCode" integer NOT NULL DEFAULT -1,
+  PRIMARY KEY ("ID", "SequencePosition"),
+  CHECK ("Status" IN
+    ('SendingOK','SendingOKNoReport','SendingError','DeliveryOK','DeliveryFailed','DeliveryPending',
+     'DeliveryUnknown','Error')),
+  CHECK ("Coding" IN
+    ('Default_No_Compression','Unicode_No_Compression','8bit','Default_Compression','Unicode_Compression'))
+);
+
+CREATE INDEX sentitems_date ON sentitems("DeliveryDateTime");
+CREATE INDEX sentitems_tpmr ON sentitems("TPMR");
+CREATE INDEX sentitems_dest ON sentitems("DestinationNumber");
+CREATE INDEX sentitems_sender ON sentitems("SenderID");
+GO
+
+CREATE TRIGGER sentitems_update_timestamp ON sentitems AFTER UPDATE AS
+BEGIN
+  SET NOCOUNT ON;
+  IF TRIGGER_NESTLEVEL() > 1 RETURN;
+  UPDATE target
+     SET "UpdatedInDB" = CURRENT_TIMESTAMP
+    FROM sentitems AS target
+    JOIN inserted AS changed
+      ON target."ID" = changed."ID"
+     AND target."SequencePosition" = changed."SequencePosition";
+END;
+GO

--- a/smsd/CMakeTests.txt
+++ b/smsd/CMakeTests.txt
@@ -15,6 +15,12 @@ if (WITH_BACKUP)
 
     set(ODBC_DSN smsd CACHE STRING "ODBC data source name to use for MySQL tests")
 
+    set(MSSQL_HOST 127.0.0.1,1433 CACHE STRING "Host to use for Microsoft SQL Server tests")
+    set(MSSQL_DATABASE smsd CACHE STRING "Database to use for Microsoft SQL Server tests")
+    set(MSSQL_USER sa CACHE STRING "User to use for Microsoft SQL Server tests")
+    set(MSSQL_PASSWORD "" CACHE STRING "Password to use for Microsoft SQL Server tests")
+    set(MSSQL_ODBC_DSN smsd-mssql CACHE STRING "ODBC data source name to use for Microsoft SQL Server tests")
+
     configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/test-smsd.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/test-smsd.sh" ESCAPE_QUOTES)
     configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/test-smsd-files-include.sh.in" "${CMAKE_CURRENT_BINARY_DIR}/test-smsd-files-include.sh" ESCAPE_QUOTES)
 
@@ -86,6 +92,18 @@ if (WITH_BACKUP)
             message("MySQL tests disabled, mysql program not found")
         endif()
     endif (MYSQL_TESTING)
+
+    if (MSSQL_TESTING)
+        if (SQLCMD_BIN AND ODBC_FOUND AND SH_BIN)
+            smsd_testsuite("odbc-mssql")
+        elseif (NOT SQLCMD_BIN)
+            message("Microsoft SQL Server tests disabled, sqlcmd program not found")
+        elseif (NOT ODBC_FOUND)
+            message("Microsoft SQL Server tests disabled, ODBC library not found")
+        else()
+            message("Microsoft SQL Server tests disabled, sh program not found")
+        endif()
+    endif (MSSQL_TESTING)
 
     if (PSQL_TESTING)
         if (PSQL_BIN)

--- a/smsd/services/odbc.c
+++ b/smsd/services/odbc.c
@@ -125,18 +125,30 @@ const char *SMSDODBC_GetString(GSM_SMSDConfig * Config, SQL_result *res, unsigne
 
 gboolean SMSDODBC_GetBool(GSM_SMSDConfig * Config, SQL_result *res, unsigned int field)
 {
-	const char *value;
+	SQLLEN size;
+	SQLRETURN ret;
+	char value[6];
 
 	/*
 	 * Fetch booleans as text so both native bit columns ("0"/"1") and
 	 * textual SQL enums ("false"/"true", "no"/"yes") are interpreted
 	 * consistently. Some ODBC drivers successfully convert textual values
 	 * to SQL_C_BIT as zero, making a type-conversion fallback unreliable.
+	 *
+	 * Do not use SMSDODBC_GetString here. Its zero-length size probe can
+	 * fail with 22003 when a numeric or bit value is converted to text.
 	 */
-	value = SMSDODBC_GetString(Config, res, field);
-	if (value == NULL) {
+	ret = SQLGetData(res->odbc, field + 1, SQL_C_CHAR, value, sizeof(value), &size);
+	if (!SQL_SUCCEEDED(ret)) {
+		SMSDODBC_LogError(Config, ret, SQL_HANDLE_STMT, res->odbc, "SQLGetData(boolean) failed");
 		return FALSE;
 	}
+	if (size == SQL_NULL_DATA) {
+		SMSD_Log(DEBUG_SQL, Config, "Field %d returning NULL", field);
+		return FALSE;
+	}
+
+	SMSD_Log(DEBUG_SQL, Config, "Field %d returning boolean \"%s\"", field, value);
 	return GSM_StringToBool(value);
 }
 

--- a/smsd/services/odbc.c
+++ b/smsd/services/odbc.c
@@ -258,6 +258,7 @@ char * SMSDODBC_QuoteString(GSM_SMSDConfig * Config, const char *string)
 	char *encoded_text = NULL;
 	size_t i, len, pos = 0;
 	char quote = '"';
+	gboolean sql_standard_escaping = FALSE;
 
 	const char *driver_name;
 
@@ -267,14 +268,16 @@ char * SMSDODBC_QuoteString(GSM_SMSDConfig * Config, const char *string)
 		driver_name = Config->driver;
 	}
 
-	if (strcasecmp(driver_name, "mysql") == 0 ||
+	if (strcasecmp(driver_name, "mssql") == 0) {
+		quote = '\'';
+		sql_standard_escaping = TRUE;
+	} else if (strcasecmp(driver_name, "mysql") == 0 ||
 			strcasecmp(driver_name, "native_mysql") == 0 ||
 			strcasecmp(driver_name, "pgsql") == 0 ||
 			strcasecmp(driver_name, "native_pgsql") == 0 ||
 			strncasecmp(driver_name, "sqlite", 6) == 0 ||
 			strncasecmp(driver_name, "oracle", 6) == 0 ||
 			strncasecmp(driver_name, "freetds", 6) == 0 ||
-			strncasecmp(driver_name, "mssql", 6) == 0 ||
 			strcasecmp(Config->driver, "access") == 0) {
 		quote = '\'';
 	}
@@ -284,7 +287,9 @@ char * SMSDODBC_QuoteString(GSM_SMSDConfig * Config, const char *string)
 	encoded_text = (char *)malloc((len * 2) + 3);
 	encoded_text[pos++] = quote;
 	for (i = 0; i < len; i++) {
-		if (string[i] == quote || string[i] == '\\') {
+		if (string[i] == quote && sql_standard_escaping) {
+			encoded_text[pos++] = quote;
+		} else if (!sql_standard_escaping && (string[i] == quote || string[i] == '\\')) {
 			encoded_text[pos++] = '\\';
 		}
 		encoded_text[pos++] = string[i];

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -316,6 +316,9 @@ void SMSDSQL_Time2String(GSM_SMSDConfig * Config, time_t timestamp, char *static
   else if (strcasecmp(driver_name, "oracle") == 0) {
     strftime(static_buff, size, "TIMESTAMP '%Y-%m-%d %H:%M:%S'", tm);
   }
+  else if (strcasecmp(driver_name, "mssql") == 0) {
+    strftime(static_buff, size, "%Y-%m-%dT%H:%M:%S", tm);
+  }
   else if (strcasecmp(Config->driver, "odbc") == 0) {
     strftime(static_buff, size, "{ ts '%Y-%m-%d %H:%M:%S' }", tm);
   }

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -46,7 +46,7 @@ const char now_plus_odbc[] = "{fn CURRENT_TIMESTAMP()} + INTERVAL %d SECOND";
 const char now_plus_mysql[] = "(NOW() + INTERVAL %d SECOND) + 0";
 const char now_plus_pgsql[] = "now() + interval '%d seconds'";
 const char now_plus_sqlite[] = "datetime('now', '+%d seconds', 'localtime')";
-const char now_plus_freetds[] = "DATEADD('second', %d, CURRENT_TIMESTAMP)";
+const char now_plus_freetds[] = "DATEADD(second, %d, CURRENT_TIMESTAMP)";
 const char now_plus_access[] = "now()+#00:00:%d#";
 const char now_plus_oracle[] = "CURRENT_TIMESTAMP + INTERVAL '%d' SECOND";
 const char now_plus_fallback[] = "NOW() + INTERVAL %d SECOND";
@@ -65,7 +65,7 @@ static const char *SMSDSQL_NowPlus(GSM_SMSDConfig * Config, int seconds)
 		snprintf(result, sizeof(result), now_plus_pgsql, seconds);
 	} else if (strncasecmp(driver_name, "sqlite", 6) == 0) {
 		snprintf(result, sizeof(result), now_plus_sqlite, seconds);
-	} else if (strcasecmp(driver_name, "freetds") == 0) {
+	} else if (strcasecmp(driver_name, "freetds") == 0 || strcasecmp(driver_name, "mssql") == 0) {
 		snprintf(result, sizeof(result), now_plus_freetds, seconds);
 	} else if (strcasecmp(driver_name, "access") == 0) {
 		snprintf(result, sizeof(result), now_plus_access, seconds);
@@ -182,6 +182,7 @@ const char currtime_mysql[] = "CURTIME()";
 const char currtime_pgsql[] = "localtime";
 const char currtime_sqlite[] = "time('now', 'localtime')";
 const char currtime_freetds[] = "CURRENT_TIME";
+const char currtime_mssql[] = "CAST(CURRENT_TIMESTAMP AS time)";
 const char currtime_fallback[] = "CURTIME()";
 
 static const char *SMSDSQL_CurrentTime(GSM_SMSDConfig * Config)
@@ -196,7 +197,9 @@ static const char *SMSDSQL_CurrentTime(GSM_SMSDConfig * Config)
 		return currtime_pgsql;
 	} else if (strncasecmp(driver_name, "sqlite", 6) == 0) {
 		return currtime_sqlite;
-	} else if (strcasecmp(Config->driver, "oracle") == 0 || strcasecmp(driver_name, "freetds") == 0 || strcasecmp(driver_name, "mssql") == 0 || strcasecmp(driver_name, "sybase") == 0) {
+	} else if (strcasecmp(driver_name, "mssql") == 0) {
+		return currtime_mssql;
+	} else if (strcasecmp(Config->driver, "oracle") == 0 || strcasecmp(driver_name, "freetds") == 0 || strcasecmp(driver_name, "sybase") == 0) {
 		return currtime_freetds;
 	} else if (strcasecmp(Config->driver, "odbc") == 0) {
 		return currtime_odbc;

--- a/smsd/test-smsd.sh.in
+++ b/smsd/test-smsd.sh.in
@@ -201,7 +201,7 @@ case $SERVICE in
         echo "INSERT INTO outbox(\"DestinationNumber\",\"TextDecoded\",\"CreatorID\",\"Coding\") VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');" | PGPASSWORD="@PSQL_PASSWORD@" "@PSQL_BIN@" -h "@PSQL_HOST@" -U "@PSQL_USER@" "@PSQL_DATABASE@"
         ;;
     odbc-mssql)
-        "@SQLCMD_BIN@" -C -b -S "@MSSQL_HOST@" -U "@MSSQL_USER@" -P "@MSSQL_PASSWORD@" -d "@MSSQL_DATABASE@" -Q "INSERT INTO outbox(\"DestinationNumber\",\"TextDecoded\",\"CreatorID\",\"Coding\") VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');"
+        "@SQLCMD_BIN@" -C -b -S "@MSSQL_HOST@" -U "@MSSQL_USER@" -P "@MSSQL_PASSWORD@" -d "@MSSQL_DATABASE@" -Q "INSERT INTO outbox(DestinationNumber,TextDecoded,CreatorID,Coding) VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');"
         ;;
     *mysql|odbc)
         echo "INSERT INTO outbox(DestinationNumber,TextDecoded,CreatorID,Coding) VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');" | "@MYSQL_BIN@" "-u@MYSQL_USER@" "-h@MYSQL_HOST@" "-p@MYSQL_PASSWORD@" "@MYSQL_DATABASE@"

--- a/smsd/test-smsd.sh.in
+++ b/smsd/test-smsd.sh.in
@@ -114,6 +114,16 @@ password = @MYSQL_PASSWORD@
 sql = mysql
 EOT
         ;;
+    odbc-mssql)
+        cat >> .smsdrc <<EOT
+service = sql
+driver = odbc
+pc = @MSSQL_ODBC_DSN@
+user = @MSSQL_USER@
+password = @MSSQL_PASSWORD@
+sql = mssql
+EOT
+        ;;
     null)
         TEST_MATCH=";999999999999999;994299429942994;0;9;0;100;42"
         INCOMING_USSD=0
@@ -143,6 +153,9 @@ case $SERVICE in
     *pgsql)
         echo "DROP TABLE IF EXISTS gammu, inbox, outbox, outbox_multipart, phones, sentitems;" | PGPASSWORD="@PSQL_PASSWORD@" "@PSQL_BIN@" -h "@PSQL_HOST@" -U "@PSQL_USER@" "@PSQL_DATABASE@"
         PGPASSWORD="@PSQL_PASSWORD@" "@PSQL_BIN@" -h "@PSQL_HOST@" -U "@PSQL_USER@" "@PSQL_DATABASE@" < "@CMAKE_CURRENT_SOURCE_DIR@/../docs/sql/pgsql.sql" 2>&1 | grep -v 'ERROR.*language "plpgsql" already exists'
+        ;;
+    odbc-mssql)
+        "@SQLCMD_BIN@" -C -b -S "@MSSQL_HOST@" -U "@MSSQL_USER@" -P "@MSSQL_PASSWORD@" -d "@MSSQL_DATABASE@" -i "@CMAKE_CURRENT_SOURCE_DIR@/../docs/sql/mssql.sql"
         ;;
     *mysql|odbc)
         echo "DROP TABLE IF EXISTS gammu, inbox, outbox, outbox_multipart, phones, sentitems;" | "@MYSQL_BIN@" "-u@MYSQL_USER@" "-h@MYSQL_HOST@" "-p@MYSQL_PASSWORD@" "@MYSQL_DATABASE@"
@@ -186,6 +199,9 @@ case $SERVICE in
         ;;
     *pgsql)
         echo "INSERT INTO outbox(\"DestinationNumber\",\"TextDecoded\",\"CreatorID\",\"Coding\") VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');" | PGPASSWORD="@PSQL_PASSWORD@" "@PSQL_BIN@" -h "@PSQL_HOST@" -U "@PSQL_USER@" "@PSQL_DATABASE@"
+        ;;
+    odbc-mssql)
+        "@SQLCMD_BIN@" -C -b -S "@MSSQL_HOST@" -U "@MSSQL_USER@" -P "@MSSQL_PASSWORD@" -d "@MSSQL_DATABASE@" -Q "INSERT INTO outbox(\"DestinationNumber\",\"TextDecoded\",\"CreatorID\",\"Coding\") VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');"
         ;;
     *mysql|odbc)
         echo "INSERT INTO outbox(DestinationNumber,TextDecoded,CreatorID,Coding) VALUES('800123465', 'This is a SQL test message', 'T3st', 'Default_No_Compression');" | "@MYSQL_BIN@" "-u@MYSQL_USER@" "-h@MYSQL_HOST@" "-p@MYSQL_PASSWORD@" "@MYSQL_DATABASE@"

--- a/smsd/test-smsd.sh.in
+++ b/smsd/test-smsd.sh.in
@@ -211,9 +211,13 @@ case $SERVICE in
         ;;
 esac
 
+$SMSD_INJECT_CMD -c "$CONFIG_PATH" TEXT 123465 -text "Don't panic." &
+INJECT_PID_1=$!
 $SMSD_INJECT_CMD -c "$CONFIG_PATH" TEXT 123465 -text "Lorem ipsum." &
-$SMSD_INJECT_CMD -c "$CONFIG_PATH" TEXT 123465 -text "Lorem ipsum." &
+INJECT_PID_2=$!
 $SMSD_INJECT_CMD -c "$CONFIG_PATH" USSD "*127*1#"
+wait "$INJECT_PID_1"
+wait "$INJECT_PID_2"
 
 $SMSD_CMD -c "$CONFIG_PATH" $SMSD_EXTRA_PARAMS &
 SMSD_PID=$!

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,11 @@ if (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H OR ODBC_FOU
 
     if (ODBC_FOUND)
         include_directories (${ODBC_INCLUDE_DIR})
+
+        add_executable(odbc-quote-string odbc-quote-string.c)
+        add_coverage(odbc-quote-string)
+        target_link_libraries (odbc-quote-string gsmsd)
+        add_test(odbc-quote-string "${GAMMU_TEST_PATH}/odbc-quote-string${CMAKE_EXECUTABLE_SUFFIX}")
     endif (ODBC_FOUND)
 
     add_executable(sql-parse-date sql-parse-date.c)

--- a/tests/atgen/test_sql_time.c
+++ b/tests/atgen/test_sql_time.c
@@ -34,12 +34,22 @@ GSM_DateTime *mk_dt(
   return &dt;
 }
 
-void get_sql_string(char *dest, const char* driver_name, time_t posix_time)
+void get_sql_string_for_dialect(
+  char *dest,
+  const char *driver_name,
+  const char *sql_name,
+  time_t posix_time)
 {
   GSM_SMSDConfig config;
   memset(&config, 0, sizeof(GSM_SMSDConfig));
   config.driver = driver_name;
+  config.sql = sql_name;
   SMSDSQL_Time2String(&config, posix_time, dest, 128);
+}
+
+void get_sql_string(char *dest, const char *driver_name, time_t posix_time)
+{
+  get_sql_string_for_dialect(dest, driver_name, NULL, posix_time);
 }
 
 /**************************************************/
@@ -293,6 +303,24 @@ void odbc_timestamp(void)
   test_result(strcmp("{ ts '2019-12-08 11:48:44' }", actual) == 0);
 }
 
+void mssql_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 12, 8, 11, 48, 44, 0);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/London");
+#else
+  putenv("TZ=GMT0");
+  tzset();
+#endif
+  get_sql_string_for_dialect(actual, "odbc", "mssql", Fill_Time_T(dt));
+
+  test_result(strcmp("2019-12-08T11:48:44", actual) == 0);
+}
+
 void access_timestamp(void)
 {
   GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, 0);
@@ -332,5 +360,6 @@ int main(void)
   oracle_timestamp();
 
   odbc_timestamp();
+  mssql_timestamp();
   access_timestamp();
 }

--- a/tests/odbc-quote-string.c
+++ b/tests/odbc-quote-string.c
@@ -7,6 +7,7 @@
 
 #include <gammu-smsd.h>
 
+#include "../smsd/core.h"
 #include "common.h"
 
 extern char *SMSDODBC_QuoteString(GSM_SMSDConfig *Config, const char *string);

--- a/tests/odbc-quote-string.c
+++ b/tests/odbc-quote-string.c
@@ -1,0 +1,28 @@
+/**
+ * Tests ODBC string literal escaping.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <gammu-smsd.h>
+
+#include "common.h"
+
+extern char *SMSDODBC_QuoteString(GSM_SMSDConfig *Config, const char *string);
+
+int main(int argc UNUSED, char **argv UNUSED)
+{
+	GSM_SMSDConfig config;
+	char *quoted;
+
+	memset(&config, 0, sizeof(config));
+	config.driver = "odbc";
+	config.sql = "mssql";
+
+	quoted = SMSDODBC_QuoteString(&config, "Don't panic. C:\\temp");
+	test_result(strcmp(quoted, "'Don''t panic. C:\\temp'") == 0);
+	free(quoted);
+
+	return 0;
+}


### PR DESCRIPTION
ODBC behavior varies by database and driver, while CI only exercised MySQL-backed ODBC. Run the SMSD integration harness against a pinned SQL Server 2022 CU26 service with Microsoft's ODBC 18 driver, including the required schema and T-SQL dialect corrections.