### PR TITLE
Fix C API function lookup in the manual

### DIFF
--- a/docs/manual/conf.py
+++ b/docs/manual/conf.py
@@ -284,10 +284,36 @@ latex_domain_indices = True
 # -- Options for breathe extension ----------------------------------------
 
 breathe_projects = {
-    "api": "@DOXYGEN_OUTPUT@/xml",
+    # Use a path relative to this configuration directory; breathe resolves
+    # it against the sphinx confdir but prints it verbatim in warnings, so
+    # an absolute path would end up embedded in the generated HTML and make
+    # the build unreproducible.
+    "api": os.path.relpath(
+        "@DOXYGEN_OUTPUT@/xml", os.path.abspath(os.path.dirname(__file__))
+    ),
 }
 
 breathe_default_project = "api"
+
+# Doxygen 1.9.7 and newer no longer duplicate the definitions of grouped
+# members into the file compound XML output. Breathe's doxygenfunction
+# directive skips members whose parent compound is a group, expecting to
+# find the duplicated entry under the file compound, so every function
+# lookup fails. Allow group members again; with the new doxygen behavior
+# each function is found exactly once, in its group.
+# See https://github.com/breathe-doc/breathe/issues/934
+import breathe.renderer.filter
+
+
+def _function_and_all_friend_finder_filter(self, namespace, name):
+    return self.create_member_finder_filter(
+        namespace, name, "function"
+    ) | self.create_member_finder_filter(namespace, name, "friend")
+
+
+breathe.renderer.filter.FilterFactory.create_function_and_all_friend_finder_filter = (
+    _function_and_all_friend_finder_filter
+)
 
 
 breathe_domain_by_extension = {


### PR DESCRIPTION
Doxygen 1.9.7 and newer no longer duplicate the definitions of grouped members into the file compound XML output. Breathe's doxygenfunction directive deliberately skips members whose parent compound is a group, expecting to find the duplicate entry under the file compound. With the duplication gone, every function lookup fails, all C API pages degrade to "Cannot find function" warnings and the real documentation is lost. The warning text also embeds the absolute doxygen XML path, making the gammu-doc package unreproducible (file-references-package-build-path).

Override the breathe finder filter from conf.py to allow group members; with the new doxygen behavior each function is found exactly once, in its group. Also pass the breathe project path relative to the sphinx configuration directory so any remaining breathe warning cannot embed the build path in the generated HTML.