### PR TITLE
fix(smsd): honor SQL dialect for ODBC timestamps

### DIFF
--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -319,7 +319,7 @@ void SMSDSQL_Time2String(GSM_SMSDConfig * Config, time_t timestamp, char *static
   else if (strcasecmp(driver_name, "mssql") == 0) {
     strftime(static_buff, size, "%Y-%m-%dT%H:%M:%S", tm);
   }
-  else if (strcasecmp(Config->driver, "odbc") == 0) {
+  else if (strcasecmp(driver_name, "odbc") == 0) {
     strftime(static_buff, size, "{ ts '%Y-%m-%d %H:%M:%S' }", tm);
   }
   else if (strcasecmp(driver_name, "access") == 0) {

--- a/tests/atgen/test_sql_time.c
+++ b/tests/atgen/test_sql_time.c
@@ -267,6 +267,24 @@ void mysql_timestamp(void)
   test_result(strcmp("2019-05-08 13:48:44", actual) == 0);
 }
 
+void mysql_odbc_timestamp(void)
+{
+  GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, 0);
+  char actual[128];
+
+  puts(__func__);
+
+#ifndef WIN32
+  putenv((char*)"TZ=:Europe/Warsaw");
+#else
+  putenv("TZ=CET-2");
+  tzset();
+#endif
+  get_sql_string_for_dialect(actual, "odbc", "mysql", Fill_Time_T(dt));
+
+  test_result(strcmp("2019-05-08 13:48:44", actual) == 0);
+}
+
 void oracle_timestamp(void)
 {
   GSM_DateTime dt = *mk_dt(2019, 5, 8, 11, 48, 44, -3);
@@ -357,6 +375,7 @@ int main(void)
 
   pgsql_timestamp();
   mysql_timestamp();
+  mysql_odbc_timestamp();
   oracle_timestamp();
 
   odbc_timestamp();


### PR DESCRIPTION
ODBC timestamp escapes are quoted as string data by named-query expansion, causing MySQL to reject them as invalid datetimes. Use the configured SQL dialect when formatting timestamps.

Closes #82

Closes #564