### PR TITLE
fix(at): handle unsolicited Huawei network time

### DIFF
--- a/libgammu/gsmstate.c
+++ b/libgammu/gsmstate.c
@@ -8,6 +8,11 @@
 #include <limits.h>
 #include <assert.h>
 #include <stdio.h>
+#include <time.h>
+
+#ifndef WIN32
+#include <sys/time.h>
+#endif
 
 #include <gammu-call.h>
 #include <gammu-settings.h>
@@ -990,6 +995,22 @@ gboolean GSM_IsConnected(GSM_StateMachine *s) {
 	return (s != NULL) && s->Phone.Functions != NULL && s->opened;
 }
 
+static unsigned long GSM_GetWaitTime(void)
+{
+#ifdef WIN32
+	return GetTickCount();
+#else
+	struct timeval now;
+
+	if (gettimeofday(&now, NULL) != 0) {
+		return (unsigned long)time(NULL) * 1000UL;
+	}
+
+	return (unsigned long)now.tv_sec * 1000UL +
+	       (unsigned long)now.tv_usec / 1000UL;
+#endif
+}
+
 GSM_Error GSM_AbortOperation(GSM_StateMachine * s)
 {
 	s->Abort = TRUE;
@@ -1001,7 +1022,11 @@ GSM_Error GSM_WaitForOnce(GSM_StateMachine *s, const unsigned char *buffer,
 {
 	GSM_Phone_Data *Phone = &s->Phone.Data;
 	GSM_Protocol_Message sentmsg;
-	int i = 0;
+	unsigned long start;
+	unsigned long timeout_ms;
+
+	start = GSM_GetWaitTime();
+	timeout_ms = timeout > 0 ? (unsigned long)timeout * 1000UL : 0;
 
 	do {
 		if (length != 0) {
@@ -1012,10 +1037,7 @@ GSM_Error GSM_WaitForOnce(GSM_StateMachine *s, const unsigned char *buffer,
 			Phone->SentMsg  = &sentmsg;
 		}
 
-		/* Some data received. Reset timer */
-		if (GSM_ReadDevice(s, TRUE) > 0) {
-			i = 0;
-		} else {
+		if (GSM_ReadDevice(s, TRUE) <= 0) {
 			usleep(10000);
 		}
 
@@ -1033,8 +1055,7 @@ GSM_Error GSM_WaitForOnce(GSM_StateMachine *s, const unsigned char *buffer,
 		if (Phone->RequestID == ID_None) {
 			return Phone->DispatchError;
 		}
-		i++;
-	} while (i < timeout);
+	} while (GSM_GetWaitTime() - start < timeout_ms);
 
 	return ERR_TIMEOUT;
 }

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -6408,6 +6408,7 @@ GSM_Reply_Function ATGENReplyFunctions[] = {
 {ATGEN_GenericReplyIgnore, 	"^SRVST:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"^SIMST:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore,	"^STIN:"		,0x00,0x00,ID_IncomingFrame	 },
+{ATGEN_GenericReplyIgnore,	"^NWTIME:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+ZUSIMR:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+SPNWNAME:"		,0x00,0x00,ID_IncomingFrame	 },
 {ATGEN_GenericReplyIgnore, 	"+PSBEARER:"	,0x00,0x00,ID_IncomingFrame	 },

--- a/libgammu/protocol/at/at.c
+++ b/libgammu/protocol/at/at.c
@@ -139,6 +139,7 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 		{"^SRVST:"	,1, ID_All}, /* ^SRVST:0 */
 		{"^SIMST:"	,1, ID_All}, /* ^SIMST:1 */
 		{"^STIN:"	,1, ID_All}, /* ^STIN: 7, 0, 0 */
+		{"^NWTIME:"	,1, ID_All}, /* ^NWTIME: 18/03/09,12:36:21+4,00 */
 
 		/* D-Link */
 		{"+SPNWNAME:"	,1, ID_All}, /* +SPNWNAME: "432", "11", "Mci", "Mci" */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1022,6 +1022,12 @@ if (WITH_ATGEN)
     add_test(at-statemachine "${GAMMU_TEST_PATH}/at-statemachine${CMAKE_EXECUTABLE_SUFFIX}")
 endif (WITH_ATGEN)
 
+# Reply timeout
+add_executable(wait-reply-timeout wait-reply-timeout.c)
+add_coverage(wait-reply-timeout)
+target_link_libraries(wait-reply-timeout libGammu ${LIBINTL_LIBRARIES})
+add_test(wait-reply-timeout "${GAMMU_TEST_PATH}/wait-reply-timeout${CMAKE_EXECUTABLE_SUFFIX}")
+
 # Line parser tests
 add_executable(line-splitting line-splitting.c)
 add_coverage(line-splitting)

--- a/tests/at-statemachine.c
+++ b/tests/at-statemachine.c
@@ -14,11 +14,14 @@ static const char *test_data = "+CUSD: 2,\"Maaf, permintaan Anda tidak dapat kam
 
 static const char *second_test = "+CMTI: \"SM\",1\r\nAT+CPMS=\"SM\",\"SM\"\r\r\n+CPMS: 1,20,1,20,1,20\r\n\r\nOK\r\n";
 
+static const char *nwtime_test = "^NWTIME: 18/03/09,12:36:21+4,00\r\nAT+CPMS=\"SM\",\"SM\"\r\r\n+CPMS: 0,20,0,20,0,20\r\n\r\nOK\r\n";
+
 int main(int argc UNUSED, char **argv UNUSED)
 {
 	GSM_Debug_Info *debug_info;
 	GSM_Phone_ATGENData *Priv;
 	GSM_Phone_Data *Data;
+	GSM_SMSMemoryStatus SMSStatus;
 	GSM_StateMachine *s;
 	GSM_Protocol_ATData *d;
 	size_t i;
@@ -85,6 +88,22 @@ int main(int argc UNUSED, char **argv UNUSED)
 	}
 
 	test_result(s->MessagesCount == 6);
+
+	memset(&SMSStatus, 0, sizeof(SMSStatus));
+	Data->SMSStatus = &SMSStatus;
+	Data->RequestID = ID_GetSMSStatus;
+
+	/* Unsolicited Huawei network time must not contaminate a command reply. */
+	for (i = 0; i < strlen(nwtime_test); i++) {
+		error = AT_StateMachine(s, nwtime_test[i]);
+		gammu_test_result(error, "AT_StateMachine");
+	}
+
+	test_result(Data->RequestID == ID_None);
+	test_result(Data->DispatchError == ERR_NONE);
+	test_result(SMSStatus.SIMUsed == 0);
+	test_result(SMSStatus.SIMSize == 20);
+	test_result(s->MessagesCount == 8);
 
 	/* Free state machine */
 	GSM_FreeStateMachine(s);

--- a/tests/wait-reply-timeout.c
+++ b/tests/wait-reply-timeout.c
@@ -1,0 +1,60 @@
+/* Test that unrelated traffic cannot indefinitely extend reply timeouts. */
+
+#include <gammu.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "common.h"
+#include "../libgammu/gsmstate.h"
+
+#define BUSY_READ_LIMIT 12
+#define BUSY_READ_DELAY 150000
+
+static int read_count = 0;
+
+static ssize_t busy_read(GSM_StateMachine *s UNUSED, void *buf, size_t nbytes)
+{
+	if (read_count >= BUSY_READ_LIMIT || nbytes == 0) {
+		return 0;
+	}
+
+	usleep(BUSY_READ_DELAY);
+	((unsigned char *)buf)[0] = 'x';
+	read_count++;
+	return 1;
+}
+
+static GSM_Error ignore_char(GSM_StateMachine *s UNUSED,
+			     unsigned char rx_char UNUSED)
+{
+	return ERR_NONE;
+}
+
+int main(int argc UNUSED, char **argv UNUSED)
+{
+	GSM_Device_Functions device = {NULL, NULL, NULL, NULL, NULL,
+				       busy_read, NULL};
+	GSM_Protocol_Functions protocol = {NULL, ignore_char, NULL, NULL};
+	GSM_Phone_Functions phone;
+	GSM_StateMachine *s;
+	GSM_Error error;
+
+	memset(&phone, 0, sizeof(phone));
+
+	s = GSM_AllocStateMachine();
+	test_result(s != NULL);
+
+	s->opened = TRUE;
+	s->Device.Functions = &device;
+	s->Protocol.Functions = &protocol;
+	s->Phone.Functions = &phone;
+	s->Phone.Data.RequestID = ID_GetSignalQuality;
+
+	error = GSM_WaitForOnce(s, NULL, 0, 0, 1);
+
+	gammu_test_result_code(error, "Wait timeout", ERR_TIMEOUT);
+	test_result(read_count < BUSY_READ_LIMIT);
+
+	GSM_FreeStateMachine(s);
+	return 0;
+}


### PR DESCRIPTION
Huawei modems can interleave ^NWTIME with command replies, leaving the active request pending while subsequent traffic continually resets its timeout. Treat the notification as an incoming frame and enforce a fixed reply deadline so SMSD cannot stall indefinitely.

Closes #392