### PR TITLE
fix(smsd): handle long filenames in FILES outbox

### DIFF
--- a/smsd/core.c
+++ b/smsd/core.c
@@ -966,6 +966,7 @@ GSM_Error SMSD_ReadConfig(const char *filename, GSM_SMSDConfig *Config, gboolean
 	}
 
 	Config->retries 	  = 0;
+	Config->SMSID[0] 	  = 0;
 	Config->prevSMSID[0] 	  = 0;
 	Config->relativevalidity  = -1;
 	Config->Status = NULL;
@@ -1813,6 +1814,8 @@ GSM_Error SMSD_SendSMS(GSM_SMSDConfig *Config)
 	for (i = 0; i < GSM_MAX_MULTI_SMS; i++) {
 		GSM_SetDefaultSMSData(&sms.SMS[i]);
 	}
+	sms.Number = 0;
+	Config->SMSID[0] = 0;
 
 	error = Config->Service->FindOutboxSMS(&sms, Config, Config->SMSID);
 
@@ -1823,11 +1826,13 @@ GSM_Error SMSD_SendSMS(GSM_SMSDConfig *Config)
 	if (error != ERR_NONE) {
 		/* Unknown error - escape */
 		SMSD_Log(DEBUG_INFO, Config, "Error in outbox on '%s'", Config->SMSID);
-		for (i = 0; i < sms.Number; i++) {
-			Config->Status->Failed++;
-			Config->Service->AddSentSMSInfo(&sms, Config, Config->SMSID, i+1, SMSD_SEND_ERROR, -1);
+		if (Config->SMSID[0] != 0) {
+			for (i = 0; i < sms.Number; i++) {
+				Config->Status->Failed++;
+				Config->Service->AddSentSMSInfo(&sms, Config, Config->SMSID, i+1, SMSD_SEND_ERROR, -1);
+			}
+			Config->Service->MoveSMS(&sms,Config, Config->SMSID, TRUE,FALSE);
 		}
-		Config->Service->MoveSMS(&sms,Config, Config->SMSID, TRUE,FALSE);
 		return error;
 	}
 

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -99,7 +99,8 @@ struct _GSM_SMSDConfig {
 	int		relativevalidity;
 	unsigned int 	retries;
 	int		currdeliveryreport;
-	unsigned char 	SMSID[200],	 prevSMSID[200];
+	unsigned char 	SMSID[GSM_MAX_FILENAME_LENGTH + 1],
+			prevSMSID[GSM_MAX_FILENAME_LENGTH + 1];
 	GSM_SMSC	SMSC, SMSCCache;
 	const char	*skipsmscnumber;
 	int		IgnoredMessages;

--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -69,6 +69,23 @@ static void SMSDFiles_DecodeNumber(char *string)
 	}
 }
 
+static GSM_Error SMSDFiles_BuildPath(char *result, size_t result_size,
+				     const char *path, const char *name,
+				     GSM_SMSDConfig *Config)
+{
+	size_t path_length = strlen(path);
+	size_t name_length = strlen(name);
+
+	if (path_length >= result_size || name_length >= result_size - path_length) {
+		SMSD_Log(DEBUG_ERROR, Config, "Path is too long: %s%s", path, name);
+		return ERR_CANTOPENFILE;
+	}
+
+	memcpy(result, path, path_length);
+	memcpy(result + path_length, name, name_length + 1);
+	return ERR_NONE;
+}
+
 /* Save SMS from phone (called Inbox sms - it's in phone Inbox) somewhere */
 static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations)
 {
@@ -202,7 +219,7 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 {
 	GSM_MultiPartSMSInfo SMSInfo;
 	GSM_WAPBookmark Bookmark;
-	char FileName[100], FullName[PATH_MAX];
+	char FileName[GSM_MAX_FILENAME_LENGTH + 1], FullName[PATH_MAX];
 	unsigned char Buffer[(GSM_MAX_SMS_LENGTH * GSM_MAX_MULTI_SMS + 1) * 2];
 	unsigned char Buffer2[(GSM_MAX_SMS_LENGTH * GSM_MAX_MULTI_SMS + 1) * 2];
 	FILE *File;
@@ -210,26 +227,35 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	size_t len, phlen;
 	char *pos1, *pos2, *options = NULL;
 	gboolean backup = FALSE;
+	GSM_Error error;
 #ifdef GSM_ENABLE_BACKUP
 	GSM_SMS_Backup *smsbackup;
-	GSM_Error error;
 #endif
 #ifdef WIN32
 	struct _finddata_t c_file;
 	intptr_t hFile;
 
-	strcpy(FullName, Config->outboxpath);
-	strcat(FullName, "OUT*.txt*");
+	error = SMSDFiles_BuildPath(FullName, sizeof(FullName), Config->outboxpath, "OUT*.txt*", Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 	hFile = _findfirst(FullName, &c_file);
 	if (hFile == -1) {
-		strcpy(FullName, Config->outboxpath);
-		strcat(FullName, "OUT*.smsbackup*");
+		error = SMSDFiles_BuildPath(FullName, sizeof(FullName), Config->outboxpath, "OUT*.smsbackup*", Config);
+		if (error != ERR_NONE) {
+			return error;
+		}
 		hFile = _findfirst(FullName, &c_file);
 		backup = TRUE;
 	}
 	if (hFile == -1) {
 		return ERR_EMPTY;
 	} else {
+		if (strlen(c_file.name) >= sizeof(FileName)) {
+			_findclose(hFile);
+			SMSD_Log(DEBUG_ERROR, Config, "Outbox filename is too long: %s", c_file.name);
+			return ERR_CANTOPENFILE;
+		}
 		strcpy(FileName, c_file.name);
 	}
 	_findclose(hFile);
@@ -238,7 +264,10 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	int cur_file, num_files;
 	char *pos;
 
-	strcpy(FullName, Config->outboxpath);
+	error = SMSDFiles_BuildPath(FullName, sizeof(FullName), Config->outboxpath, "", Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 
 	FullName[strlen(Config->outboxpath) - 1] = '\0';
 
@@ -271,7 +300,11 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	}
 	/* Remember file name */
 	if (cur_file < num_files) {
-		strcpy(FileName, namelist[cur_file]->d_name);
+		if (strlen(namelist[cur_file]->d_name) >= sizeof(FileName)) {
+			error = ERR_CANTOPENFILE;
+		} else {
+			strcpy(FileName, namelist[cur_file]->d_name);
+		}
 	}
 	/* Free scandir result */
 	for (i = 0; i < num_files; i++) {
@@ -283,11 +316,17 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	if (cur_file >= num_files) {
 		return ERR_EMPTY;
 	}
+	if (error != ERR_NONE) {
+		SMSD_Log(DEBUG_ERROR, Config, "Outbox filename exceeds the supported limit");
+		return error;
+	}
 #else
 	return ERR_NOTSUPPORTED;
 #endif
-	strcpy(FullName, Config->outboxpath);
-	strcat(FullName, FileName);
+	error = SMSDFiles_BuildPath(FullName, sizeof(FullName), Config->outboxpath, FileName, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 
 	if (backup) {
 #ifdef GSM_ENABLE_BACKUP
@@ -502,11 +541,15 @@ static GSM_Error SMSDFiles_MoveSMS(GSM_MultiSMSMessage * sms UNUSED, GSM_SMSDCon
 	}
 
 	// Calculate source path
-	strcpy(ifilename, sourcepath);
-	strcat(ifilename, ID);
+	error = SMSDFiles_BuildPath(ifilename, sizeof(ifilename), sourcepath, ID, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 	// Calculate destination path
-	strcpy(ofilename, destpath);
-	strcat(ofilename, ID);
+	error = SMSDFiles_BuildPath(ofilename, sizeof(ofilename), destpath, ID, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 
 	// Do move only if paths are not same
 	if (strcmp(ifilename, ofilename) != 0) {
@@ -692,8 +735,10 @@ static GSM_Error SMSDFiles_AddSentSMSInfo(GSM_MultiSMSMessage * sms UNUSED, GSM_
 			 Config->SMSID, (Part == sms->Number ? "total" : "part"), Part, DecodeUnicodeString(sms->SMS[0].Number), TPMR);
 	}
 
-	strcpy(FullPath, Config->outboxpath);
-	strcat(FullPath, Config->SMSID);
+	error = SMSDFiles_BuildPath((char *)FullPath, sizeof(FullPath), Config->outboxpath, (char *)Config->SMSID, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 
 	// Read file content
 	GSMFile.Buffer = NULL;

--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -69,9 +69,9 @@ static void SMSDFiles_DecodeNumber(char *string)
 	}
 }
 
-static GSM_Error SMSDFiles_BuildPath(char *result, size_t result_size,
-				     const char *path, const char *name,
-				     GSM_SMSDConfig *Config)
+static GSM_Error SMSDFiles_ValidatePath(size_t result_size,
+					const char *path, const char *name,
+					GSM_SMSDConfig *Config)
 {
 	size_t path_length = strlen(path);
 	size_t name_length = strlen(name);
@@ -80,9 +80,21 @@ static GSM_Error SMSDFiles_BuildPath(char *result, size_t result_size,
 		SMSD_Log(DEBUG_ERROR, Config, "Path is too long: %s%s", path, name);
 		return ERR_CANTOPENFILE;
 	}
+	return ERR_NONE;
+}
 
-	memcpy(result, path, path_length);
-	memcpy(result + path_length, name, name_length + 1);
+static GSM_Error SMSDFiles_BuildPath(char *result, size_t result_size,
+				     const char *path, const char *name,
+				     GSM_SMSDConfig *Config)
+{
+	GSM_Error error;
+
+	error = SMSDFiles_ValidatePath(result_size, path, name, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
+
+	snprintf(result, result_size, "%s%s", path, name);
 	return ERR_NONE;
 }
 
@@ -327,6 +339,14 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	if (error != ERR_NONE) {
 		return error;
 	}
+	error = SMSDFiles_ValidatePath(sizeof(FullName), Config->sentsmspath, FileName, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
+	error = SMSDFiles_ValidatePath(sizeof(FullName), Config->errorsmspath, FileName, Config);
+	if (error != ERR_NONE) {
+		return error;
+	}
 
 	if (backup) {
 #ifdef GSM_ENABLE_BACKUP
@@ -492,6 +512,10 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 			return ERR_UNKNOWN;
 		}
 
+		if (phlen > GSM_MAX_NUMBER_LENGTH) {
+			SMSD_Log(DEBUG_ERROR, Config, "Recipient in outbox filename is too long: %s", ID);
+			return ERR_INVALIDDATA;
+		}
 		SMSDFiles_DecodeNumber(pos1);
 		for (i = 0; i < sms->Number; i++) {
 			EncodeUnicode(sms->SMS[i].Number, pos1, phlen);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1242,13 +1242,15 @@ add_test(smsd-files-unicode-write
     "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-inbox/")
 set_tests_properties(smsd-files-unicode-write PROPERTIES SKIP_RETURN_CODE 77)
 
-file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data")
-add_executable(smsd-files-outbox smsd-files-outbox.c)
-add_coverage(smsd-files-outbox)
-target_link_libraries(smsd-files-outbox libGammu ${LIBINTL_LIBRARIES} gsmsd)
-add_test(smsd-files-long-outbox-name
-    "${GAMMU_TEST_PATH}/smsd-files-outbox${CMAKE_EXECUTABLE_SUFFIX}"
-    "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data/")
+if (WIN32 OR (HAVE_DIRENT_H AND HAVE_SCANDIR AND HAVE_ALPHASORT))
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data")
+    add_executable(smsd-files-outbox smsd-files-outbox.c)
+    add_coverage(smsd-files-outbox)
+    target_link_libraries(smsd-files-outbox libGammu ${LIBINTL_LIBRARIES} gsmsd)
+    add_test(smsd-files-long-outbox-name
+        "${GAMMU_TEST_PATH}/smsd-files-outbox${CMAKE_EXECUTABLE_SUFFIX}"
+        "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data/")
+endif()
 
 if (NOT WIN32)
     add_executable(smsd-run-helper smsd-run-helper.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1243,13 +1243,14 @@ add_test(smsd-files-unicode-write
 set_tests_properties(smsd-files-unicode-write PROPERTIES SKIP_RETURN_CODE 77)
 
 if (WIN32 OR (HAVE_DIRENT_H AND HAVE_SCANDIR AND HAVE_ALPHASORT))
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data")
+    # Leave room for long basenames within the Windows MAX_PATH limit.
+    file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/smsd-outbox")
     add_executable(smsd-files-outbox smsd-files-outbox.c)
     add_coverage(smsd-files-outbox)
     target_link_libraries(smsd-files-outbox libGammu ${LIBINTL_LIBRARIES} gsmsd)
     add_test(smsd-files-long-outbox-name
         "${GAMMU_TEST_PATH}/smsd-files-outbox${CMAKE_EXECUTABLE_SUFFIX}"
-        "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data/")
+        "${CMAKE_BINARY_DIR}/smsd-outbox/")
 endif()
 
 if (NOT WIN32)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1242,6 +1242,14 @@ add_test(smsd-files-unicode-write
     "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-inbox/")
 set_tests_properties(smsd-files-unicode-write PROPERTIES SKIP_RETURN_CODE 77)
 
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data")
+add_executable(smsd-files-outbox smsd-files-outbox.c)
+add_coverage(smsd-files-outbox)
+target_link_libraries(smsd-files-outbox libGammu ${LIBINTL_LIBRARIES} gsmsd)
+add_test(smsd-files-long-outbox-name
+    "${GAMMU_TEST_PATH}/smsd-files-outbox${CMAKE_EXECUTABLE_SUFFIX}"
+    "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-outbox-data/")
+
 if (NOT WIN32)
     add_executable(smsd-run-helper smsd-run-helper.c)
     add_coverage(smsd-run-helper)

--- a/tests/smsd-files-outbox.c
+++ b/tests/smsd-files-outbox.c
@@ -1,13 +1,79 @@
 #include <gammu.h>
 
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#ifdef WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 #include "../smsd/core.h"
 #include "../smsd/services/files.h"
 
 #define TEST_FILENAME_LENGTH 180
+
+static char *CreateOutboxFile(const char *outbox_path, const char *filename)
+{
+	char *full_path;
+	size_t full_path_length;
+	FILE *file;
+	int fd;
+
+	full_path_length = strlen(outbox_path) + strlen(filename) + 1;
+	full_path = malloc(full_path_length);
+	if (full_path == NULL) {
+		fprintf(stderr, "Failed to allocate outbox path\n");
+		return NULL;
+	}
+	snprintf(full_path, full_path_length, "%s%s", outbox_path, filename);
+
+	remove(full_path);
+	fd = open(full_path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to create outbox file: %s\n", full_path);
+		free(full_path);
+		return NULL;
+	}
+	file = fdopen(fd, "wb");
+	if (file == NULL) {
+		fprintf(stderr, "Failed to open outbox stream: %s\n", full_path);
+		close(fd);
+		remove(full_path);
+		free(full_path);
+		return NULL;
+	}
+	fputs("long filename regression", file);
+	fclose(file);
+#ifndef WIN32
+	{
+		struct stat status;
+
+		if (stat(full_path, &status) != 0 || (status.st_mode & 077) != 0) {
+			fprintf(stderr, "Outbox file permissions are not restrictive\n");
+			remove(full_path);
+			free(full_path);
+			return NULL;
+		}
+	}
+#endif
+	return full_path;
+}
+
+static void SetupConfig(GSM_SMSDConfig *config, GSM_StateMachine *state_machine,
+			const char *outbox_path, const char *sent_path,
+			const char *error_path)
+{
+	memset(config, 0, sizeof(*config));
+	config->gsm = state_machine;
+	config->outboxpath = outbox_path;
+	config->sentsmspath = sent_path;
+	config->errorsmspath = error_path;
+	config->transmitformat = "auto";
+}
 
 static int TestFilename(GSM_StateMachine *state_machine, const char *outbox_path,
 			const char *filename)
@@ -17,33 +83,16 @@ static int TestFilename(GSM_StateMachine *state_machine, const char *outbox_path
 	GSM_Error error;
 	char id[GSM_MAX_FILENAME_LENGTH + 1];
 	char *full_path;
-	size_t full_path_length;
-	FILE *file;
 	int result = 0;
 
-	full_path_length = strlen(outbox_path) + strlen(filename) + 1;
-	full_path = malloc(full_path_length);
+	full_path = CreateOutboxFile(outbox_path, filename);
 	if (full_path == NULL) {
-		fprintf(stderr, "Failed to allocate outbox path\n");
 		return 1;
 	}
-	snprintf(full_path, full_path_length, "%s%s", outbox_path, filename);
-
-	file = fopen(full_path, "wb");
-	if (file == NULL) {
-		fprintf(stderr, "Failed to create outbox file: %s\n", full_path);
-		free(full_path);
-		return 1;
-	}
-	fputs("long filename regression", file);
-	fclose(file);
 
 	memset(&sms, 0, sizeof(sms));
-	memset(&config, 0, sizeof(config));
 	memset(id, 0, sizeof(id));
-	config.gsm = state_machine;
-	config.outboxpath = outbox_path;
-	config.transmitformat = "auto";
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
 
 	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
 	if (error != ERR_NONE) {
@@ -54,6 +103,44 @@ static int TestFilename(GSM_StateMachine *state_machine, const char *outbox_path
 		result = 1;
 	} else if (sms.Number == 0 || strcmp(DecodeUnicodeString(sms.SMS[0].Number), "12345") != 0) {
 		fprintf(stderr, "Outbox recipient was not parsed correctly\n");
+		result = 1;
+	}
+
+	remove(full_path);
+	free(full_path);
+	return result;
+}
+
+static int TestInvalidRecipient(GSM_StateMachine *state_machine,
+				const char *outbox_path)
+{
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char filename[GSM_MAX_FILENAME_LENGTH + 1];
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+	char *full_path;
+	size_t recipient_length = GSM_MAX_NUMBER_LENGTH + 1;
+	int result = 0;
+
+	memcpy(filename, "OUT", 3);
+	memset(filename + 3, '1', recipient_length);
+	strcpy(filename + 3 + recipient_length, ".txt");
+	full_path = CreateOutboxFile(outbox_path, filename);
+	if (full_path == NULL) {
+		return 1;
+	}
+
+	memset(&sms, 0, sizeof(sms));
+	memset(id, 0, sizeof(id));
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
+
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_INVALIDDATA) {
+		fprintf(stderr, "Oversized recipient returned %s\n", GSM_ErrorString(error));
+		result = 1;
+	} else if (strcmp(id, filename) != 0) {
+		fprintf(stderr, "Invalid outbox filename was not preserved\n");
 		result = 1;
 	}
 
@@ -73,11 +160,8 @@ static int TestLongPath(GSM_StateMachine *state_machine)
 	memset(outbox_path, 'x', sizeof(outbox_path) - 1);
 	outbox_path[sizeof(outbox_path) - 1] = '\0';
 	memset(&sms, 0, sizeof(sms));
-	memset(&config, 0, sizeof(config));
 	memset(id, 0, sizeof(id));
-	config.gsm = state_machine;
-	config.outboxpath = outbox_path;
-	config.transmitformat = "auto";
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
 
 	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
 	if (error != ERR_CANTOPENFILE) {
@@ -85,6 +169,45 @@ static int TestLongPath(GSM_StateMachine *state_machine)
 		return 1;
 	}
 	return 0;
+}
+
+static int TestLongDestinationPath(GSM_StateMachine *state_machine,
+				   const char *outbox_path, gboolean sent)
+{
+	static const char filename[] = "OUT12345.txt";
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char destination_path[GSM_MAX_FILENAME_ID_LENGTH + 1];
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+	char *full_path;
+	int result = 0;
+
+	full_path = CreateOutboxFile(outbox_path, filename);
+	if (full_path == NULL) {
+		return 1;
+	}
+	memset(destination_path, 'x', sizeof(destination_path) - 1);
+	destination_path[sizeof(destination_path) - 1] = '\0';
+	memset(&sms, 0, sizeof(sms));
+	memset(id, 0, sizeof(id));
+	SetupConfig(&config, state_machine, outbox_path,
+		    sent ? destination_path : outbox_path,
+		    sent ? outbox_path : destination_path);
+
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_CANTOPENFILE) {
+		fprintf(stderr, "Overlong %s path returned %s\n",
+			sent ? "sent" : "error", GSM_ErrorString(error));
+		result = 1;
+	} else if (id[0] != '\0') {
+		fprintf(stderr, "Message ID was set before path validation\n");
+		result = 1;
+	}
+
+	remove(full_path);
+	free(full_path);
+	return result;
 }
 
 int main(int argc, char **argv)
@@ -117,7 +240,16 @@ int main(int argc, char **argv)
 		result = TestFilename(state_machine, argv[1], long_filename);
 	}
 	if (result == 0) {
+		result = TestInvalidRecipient(state_machine, argv[1]);
+	}
+	if (result == 0) {
 		result = TestLongPath(state_machine);
+	}
+	if (result == 0) {
+		result = TestLongDestinationPath(state_machine, argv[1], TRUE);
+	}
+	if (result == 0) {
+		result = TestLongDestinationPath(state_machine, argv[1], FALSE);
 	}
 
 	GSM_FreeStateMachine(state_machine);

--- a/tests/smsd-files-outbox.c
+++ b/tests/smsd-files-outbox.c
@@ -1,0 +1,125 @@
+#include <gammu.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../smsd/core.h"
+#include "../smsd/services/files.h"
+
+#define TEST_FILENAME_LENGTH 180
+
+static int TestFilename(GSM_StateMachine *state_machine, const char *outbox_path,
+			const char *filename)
+{
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+	char *full_path;
+	size_t full_path_length;
+	FILE *file;
+	int result = 0;
+
+	full_path_length = strlen(outbox_path) + strlen(filename) + 1;
+	full_path = malloc(full_path_length);
+	if (full_path == NULL) {
+		fprintf(stderr, "Failed to allocate outbox path\n");
+		return 1;
+	}
+	snprintf(full_path, full_path_length, "%s%s", outbox_path, filename);
+
+	file = fopen(full_path, "wb");
+	if (file == NULL) {
+		fprintf(stderr, "Failed to create outbox file: %s\n", full_path);
+		free(full_path);
+		return 1;
+	}
+	fputs("long filename regression", file);
+	fclose(file);
+
+	memset(&sms, 0, sizeof(sms));
+	memset(&config, 0, sizeof(config));
+	memset(id, 0, sizeof(id));
+	config.gsm = state_machine;
+	config.outboxpath = outbox_path;
+	config.transmitformat = "auto";
+
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_NONE) {
+		fprintf(stderr, "Failed to find outbox message: %s\n", GSM_ErrorString(error));
+		result = 1;
+	} else if (strcmp(id, filename) != 0) {
+		fprintf(stderr, "Outbox filename was not preserved\n");
+		result = 1;
+	} else if (sms.Number == 0 || strcmp(DecodeUnicodeString(sms.SMS[0].Number), "12345") != 0) {
+		fprintf(stderr, "Outbox recipient was not parsed correctly\n");
+		result = 1;
+	}
+
+	remove(full_path);
+	free(full_path);
+	return result;
+}
+
+static int TestLongPath(GSM_StateMachine *state_machine)
+{
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char outbox_path[GSM_MAX_FILENAME_ID_LENGTH + 1];
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+
+	memset(outbox_path, 'x', sizeof(outbox_path) - 1);
+	outbox_path[sizeof(outbox_path) - 1] = '\0';
+	memset(&sms, 0, sizeof(sms));
+	memset(&config, 0, sizeof(config));
+	memset(id, 0, sizeof(id));
+	config.gsm = state_machine;
+	config.outboxpath = outbox_path;
+	config.transmitformat = "auto";
+
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_CANTOPENFILE) {
+		fprintf(stderr, "Overlong outbox path returned %s\n", GSM_ErrorString(error));
+		return 1;
+	}
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	static const char prefix[] = "OUTC20260729_120000_00_12345_";
+	static const char extension[] = ".txt";
+	GSM_StateMachine *state_machine;
+	char long_filename[GSM_MAX_FILENAME_LENGTH + 1];
+	size_t filler_length;
+	int result;
+
+	if (argc != 2) {
+		fprintf(stderr, "Usage: %s OUTBOX_PATH\n", argv[0]);
+		return 1;
+	}
+
+	filler_length = TEST_FILENAME_LENGTH - strlen(prefix) - strlen(extension);
+	memcpy(long_filename, prefix, strlen(prefix));
+	memset(long_filename + strlen(prefix), 'x', filler_length);
+	memcpy(long_filename + strlen(prefix) + filler_length, extension, sizeof(extension));
+
+	state_machine = GSM_AllocStateMachine();
+	if (state_machine == NULL) {
+		fprintf(stderr, "Failed to allocate state machine\n");
+		return 1;
+	}
+
+	result = TestFilename(state_machine, argv[1], "OUT12345.txt");
+	if (result == 0) {
+		result = TestFilename(state_machine, argv[1], long_filename);
+	}
+	if (result == 0) {
+		result = TestLongPath(state_machine);
+	}
+
+	GSM_FreeStateMachine(state_machine);
+	return result;
+}


### PR DESCRIPTION
FILES outbox scanning copied valid filesystem basenames into undersized buffers, allowing a long filename to terminate gammu-smsd. Preserve supported filenames and reject paths that cannot be represented safely.

Fixes #679