### PR TITLE
fix(at): enumerate physical SMS locations

### DIFF
--- a/libgammu/gsmreply.h
+++ b/libgammu/gsmreply.h
@@ -48,6 +48,7 @@ typedef enum {
 	ID_GetSMSFolders,
 	ID_GetSMSFolderStatus,
 	ID_GetSMSStatus,
+	ID_GetSMSLocationRange,
 	ID_AddSMSFolder,
 	ID_ConfigureNetworkInfo,
 	ID_GetNetworkInfo,

--- a/libgammu/phone/at/at-sms.c
+++ b/libgammu/phone/at/at-sms.c
@@ -1414,9 +1414,288 @@ GSM_Error ATGEN_GetSMSList(GSM_StateMachine *s, gboolean first)
 		if (! GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_USE_SMSTEXTMODE)) {
 			smprintf(s, "HINT: Your might want to use F_USE_SMSTEXTMODE flag\n");
 		}
+		if (Priv->SMSCount < used) {
+			return ERR_UNKNOWNRESPONSE;
+		}
 		return ERR_NONE;
 	}
 	return error;
+}
+
+static void ATGEN_ResetSMSLocationRange(GSM_Phone_ATGENData *Priv)
+{
+	Priv->SMSLocationFirst = 0;
+	Priv->SMSLocationLast = -1;
+	Priv->SMSLocationPos = 0;
+	Priv->SMSLocationTarget = 0;
+	Priv->SMSLocationMemory = MEM_INVALID;
+	Priv->SMSLocationLegacy = FALSE;
+}
+
+static GSM_Error ATGEN_ParseSMSLocationRange(GSM_StateMachine *s, const char *buffer)
+{
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+	const char *current;
+	char *endptr;
+	gboolean found = FALSE;
+	size_t max_location;
+	long first, last;
+
+	current = strstr(buffer, "+CMGD:");
+	if (current == NULL) {
+		return ERR_UNKNOWNRESPONSE;
+	}
+	current = strchr(current, '(');
+	if (current == NULL) {
+		return ERR_UNKNOWNRESPONSE;
+	}
+	current++;
+
+	max_location = GSM_PHONE_MAXSMSINFOLDER;
+	if (GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_SMS_LOCATION_0)) {
+		max_location--;
+	}
+
+	while (isspace((unsigned char)*current)) {
+		current++;
+	}
+	while (*current != ')') {
+		first = strtol(current, &endptr, 10);
+		if (endptr == current) {
+			smprintf(s, "Failed to parse SMS location in: %s\n", buffer);
+			return ERR_UNKNOWNRESPONSE;
+		}
+		current = endptr;
+		while (isspace((unsigned char)*current)) {
+			current++;
+		}
+
+		last = first;
+		if (*current == '-') {
+			current++;
+			while (isspace((unsigned char)*current)) {
+				current++;
+			}
+			last = strtol(current, &endptr, 10);
+			if (endptr == current) {
+				smprintf(s, "Failed to parse SMS location range in: %s\n", buffer);
+				return ERR_UNKNOWNRESPONSE;
+			}
+			current = endptr;
+			while (isspace((unsigned char)*current)) {
+				current++;
+			}
+		}
+
+		if (first < 0 || last < first || (size_t)last >= max_location) {
+			smprintf(s, "Invalid SMS location range %ld-%ld\n", first, last);
+			return ERR_UNKNOWNRESPONSE;
+		}
+		if (!found || first < Priv->SMSLocationFirst) {
+			Priv->SMSLocationFirst = (int)first;
+		}
+		if (!found || last > Priv->SMSLocationLast) {
+			Priv->SMSLocationLast = (int)last;
+		}
+		found = TRUE;
+
+		if (*current == ',') {
+			current++;
+			while (isspace((unsigned char)*current)) {
+				current++;
+			}
+		} else if (*current != ')') {
+			smprintf(s, "Unexpected character in SMS location range: %c\n", *current);
+			return ERR_UNKNOWNRESPONSE;
+		}
+	}
+
+	if (!found) {
+		smprintf(s, "No supported physical SMS locations were reported\n");
+		return ERR_UNKNOWNRESPONSE;
+	}
+	Priv->SMSLocationPos = Priv->SMSLocationFirst;
+	smprintf(s, "Supported physical SMS location range is %d-%d\n",
+			Priv->SMSLocationFirst, Priv->SMSLocationLast);
+	return ERR_NONE;
+}
+
+GSM_Error ATGEN_ReplyGetSMSLocationRange(GSM_Protocol_Message *msg, GSM_StateMachine *s)
+{
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+	const char *line;
+	int i;
+
+	switch (Priv->ReplyState) {
+	case AT_Reply_OK:
+		for (i = 2; strcmp("OK", line = GetLineString(msg->Buffer, &Priv->Lines, i)) != 0; i++) {
+			if (strstr(line, "+CMGD:") != NULL) {
+				return ATGEN_ParseSMSLocationRange(s, line);
+			}
+		}
+		return ERR_UNKNOWNRESPONSE;
+	case AT_Reply_Error:
+		return ERR_NOTSUPPORTED;
+	case AT_Reply_CMSError:
+		if (Priv->ErrorCode == 302) {
+			return ERR_NOTSUPPORTED;
+		}
+		return ATGEN_HandleCMSError(s);
+	case AT_Reply_CMEError:
+		if (Priv->ErrorCode == 3) {
+			return ERR_NOTSUPPORTED;
+		}
+		return ATGEN_HandleCMEError(s);
+	default:
+		return ERR_UNKNOWNRESPONSE;
+	}
+}
+
+static gboolean ATGEN_CanUseLegacySMSLocationScan(GSM_Error error)
+{
+	return error == ERR_NOTSUPPORTED ||
+		error == ERR_UNKNOWNRESPONSE ||
+		error == ERR_INVALIDLOCATION ||
+		error == ERR_UNKNOWN;
+}
+
+static GSM_Error ATGEN_GetSMSLocationRange(GSM_StateMachine *s, GSM_MemoryType memory)
+{
+	GSM_Error error;
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+
+	Priv->SMSLocationFirst = 0;
+	Priv->SMSLocationLast = -1;
+	Priv->SMSLocationPos = 0;
+	Priv->SMSLocationTarget = memory == MEM_SM
+		? Priv->LastSMSStatus.SIMUsed
+		: Priv->LastSMSStatus.PhoneUsed;
+	Priv->SMSLocationMemory = MEM_INVALID;
+
+	error = ATGEN_SetSMSMemory(s, memory == MEM_SM, FALSE, FALSE);
+	if (error != ERR_NONE) {
+		return error;
+	}
+
+	smprintf(s, "Getting physical SMS locations from %s\n", GSM_MemoryTypeToString(memory));
+	error = ATGEN_WaitForAutoLen(s, "AT+CMGD=?\r", 0x00, 40, ID_GetSMSLocationRange);
+	if (error == ERR_NONE) {
+		if (memory == MEM_ME &&
+				GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_SMSME900) &&
+				Priv->SMSLocationFirst >= 900) {
+			Priv->SMSLocationFirst -= 899;
+			Priv->SMSLocationLast -= 899;
+			Priv->SMSLocationPos = Priv->SMSLocationFirst;
+			smprintf(s, "Normalized 900-based ME location range to %d-%d\n",
+					Priv->SMSLocationFirst, Priv->SMSLocationLast);
+		}
+		Priv->SMSLocationMemory = memory;
+	}
+	return error;
+}
+
+static unsigned char ATGEN_GetSMSLocationFolder(GSM_Phone_ATGENData *Priv, GSM_MemoryType memory)
+{
+	if (memory == MEM_ME && Priv->SIMSMSMemory == AT_AVAILABLE) {
+		return 2;
+	}
+	return 1;
+}
+
+static GSM_MemoryType ATGEN_GetFirstSMSLocationMemory(GSM_Phone_ATGENData *Priv, int location)
+{
+	if (Priv->SIMSMSMemory == AT_AVAILABLE &&
+			(Priv->PhoneSMSMemory != AT_AVAILABLE || location < GSM_PHONE_MAXSMSINFOLDER)) {
+		return MEM_SM;
+	}
+	return MEM_ME;
+}
+
+static void ATGEN_LogSMSLocationCount(GSM_StateMachine *s, GSM_MemoryType memory)
+{
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+	if (Priv->LastSMSRead != Priv->SMSLocationTarget) {
+		smprintf(s, "WARNING: CPMS reported %d used messages in %s, but %d were readable within the supported range\n",
+				Priv->SMSLocationTarget, GSM_MemoryTypeToString(memory), Priv->LastSMSRead);
+	}
+}
+
+static GSM_Error ATGEN_GetNextSMSFromLocationRange(GSM_StateMachine *s, GSM_MultiSMSMessage *sms)
+{
+	GSM_Error error;
+	GSM_Phone_ATGENData *Priv = &s->Phone.Data.Priv.ATGEN;
+	GSM_MemoryType memory;
+	unsigned char folder;
+	int location;
+
+	while (TRUE) {
+		if (Priv->SMSLocationMemory == MEM_INVALID) {
+			memory = ATGEN_GetFirstSMSLocationMemory(Priv, sms->SMS[0].Location);
+			if ((memory == MEM_SM && Priv->LastSMSStatus.SIMUsed == 0) &&
+					Priv->PhoneSMSMemory == AT_AVAILABLE) {
+				Priv->LastSMSRead = 0;
+				sms->SMS[0].Location = GSM_PHONE_MAXSMSINFOLDER;
+				memory = MEM_ME;
+			}
+			if ((memory == MEM_SM && Priv->LastSMSStatus.SIMUsed == 0) ||
+					(memory == MEM_ME && Priv->LastSMSStatus.PhoneUsed == 0)) {
+				return ERR_EMPTY;
+			}
+			error = ATGEN_GetSMSLocationRange(s, memory);
+			if (ATGEN_CanUseLegacySMSLocationScan(error)) {
+				smprintf(s, "Physical SMS location bounds are not available, using legacy scan\n");
+				Priv->SMSLocationLegacy = TRUE;
+				return ERR_NOTSUPPORTED;
+			}
+			if (error != ERR_NONE) {
+				return error;
+			}
+		}
+
+		memory = Priv->SMSLocationMemory;
+		folder = ATGEN_GetSMSLocationFolder(Priv, memory);
+		while (Priv->SMSLocationPos <= Priv->SMSLocationLast) {
+			if (Priv->LastSMSRead >= Priv->SMSLocationTarget) {
+				break;
+			}
+			location = Priv->SMSLocationPos++;
+			sms->Number = 1;
+			sms->SMS[0].Memory = memory;
+			ATGEN_SetSMSLocation(s, &sms->SMS[0], folder, location);
+			smprintf(s, "Reading SMS location %d within the supported range for %s\n",
+					location, GSM_MemoryTypeToString(memory));
+			error = ATGEN_GetSMS(s, sms);
+			if (error == ERR_NONE) {
+				Priv->LastSMSRead++;
+				return ERR_NONE;
+			}
+			if (error != ERR_EMPTY && error != ERR_INVALIDLOCATION) {
+				return error;
+			}
+		}
+
+		ATGEN_LogSMSLocationCount(s, memory);
+		if (memory == MEM_SM && Priv->PhoneSMSMemory == AT_AVAILABLE) {
+			Priv->LastSMSRead = 0;
+			sms->SMS[0].Location = GSM_PHONE_MAXSMSINFOLDER;
+			if (Priv->LastSMSStatus.PhoneUsed == 0) {
+				return ERR_EMPTY;
+			}
+			error = ATGEN_GetSMSLocationRange(s, MEM_ME);
+			if (ATGEN_CanUseLegacySMSLocationScan(error)) {
+				smprintf(s, "Physical SMS location bounds are not available for ME, using legacy scan\n");
+				Priv->SMSLocationLegacy = TRUE;
+				return ERR_NOTSUPPORTED;
+			}
+			if (error != ERR_NONE) {
+				return error;
+			}
+			continue;
+		}
+
+		smprintf(s, "No more SMS locations within the supported range\n");
+		return ERR_EMPTY;
+	}
 }
 
 GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboolean start)
@@ -1446,6 +1725,7 @@ GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboole
 		/* Start from beginning */
 		sms->SMS[0].Location = 0;
 		Priv->LastSMSRead = 0;
+		ATGEN_ResetSMSLocationRange(Priv);
 
 		/* Get list of messages */
 		error = ATGEN_GetSMSList(s, TRUE);
@@ -1494,9 +1774,11 @@ GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboole
 			/* Get list of messages */
 			error = ATGEN_GetSMSList(s, FALSE);
 
-			/* Not supported folder? We're done then. */
-			if (error == ERR_NOTSUPPORTED) {
-				return ERR_EMPTY;
+			/* Fall back when this folder can not be listed reliably. */
+			if (error == ERR_NOTSUPPORTED || error == ERR_UNKNOWNRESPONSE) {
+				ATGEN_ResetSMSLocationRange(Priv);
+				sms->SMS[0].Location = GSM_PHONE_MAXSMSINFOLDER;
+				goto get_locations;
 			}
 			if (error != ERR_NONE) {
 				return error;
@@ -1550,6 +1832,19 @@ GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboole
 		return error;
 	}
 
+get_locations:
+	if (Priv->SMSCache != NULL) {
+		free(Priv->SMSCache);
+		Priv->SMSCache = NULL;
+		Priv->SMSCount = 0;
+	}
+	if (!Priv->SMSLocationLegacy) {
+		error = ATGEN_GetNextSMSFromLocationRange(s, sms);
+		if (error != ERR_NOTSUPPORTED || !Priv->SMSLocationLegacy) {
+			return error;
+		}
+	}
+
 	/* Use brute force if listing does not work */
 	while (TRUE) {
 		sms->SMS[0].Location++;
@@ -1576,6 +1871,7 @@ GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboole
 			if (Priv->LastSMSRead >= Priv->LastSMSStatus.PhoneUsed) return ERR_EMPTY;
 		}
 		sms->SMS[0].Folder = 0;
+		sms->SMS[0].Memory = MEM_INVALID;
 		error = ATGEN_GetSMS(s, sms);
 
 		if (error == ERR_NONE) {

--- a/libgammu/phone/at/atfunc.h
+++ b/libgammu/phone/at/atfunc.h
@@ -68,6 +68,7 @@ GSM_Error ATGEN_ReplySendSMS(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyGetSMSMessage(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyGetMessageList(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyGetSMSStatus(GSM_Protocol_Message *msg, GSM_StateMachine *s);
+GSM_Error ATGEN_ReplyGetSMSLocationRange(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyGetSMSMemories(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyAddSMSMessage(GSM_Protocol_Message *msg, GSM_StateMachine *s);
 GSM_Error ATGEN_ReplyGetSMSC(GSM_Protocol_Message *msg, GSM_StateMachine *s);

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -2279,6 +2279,12 @@ GSM_Error ATGEN_Initialise(GSM_StateMachine *s)
 
 	Priv->SMSCount			= 0;
 	Priv->SMSCache			= NULL;
+	Priv->SMSLocationFirst		= 0;
+	Priv->SMSLocationLast		= -1;
+	Priv->SMSLocationPos		= 0;
+	Priv->SMSLocationTarget		= 0;
+	Priv->SMSLocationMemory		= MEM_INVALID;
+	Priv->SMSLocationLegacy		= FALSE;
 	Priv->ReplyState		= 0;
 
 	if (s->ConnectionType != GCT_IRDAAT && s->ConnectionType != GCT_BLUEAT) {
@@ -6265,6 +6271,7 @@ GSM_Reply_Function ATGENReplyFunctions[] = {
 {ATGEN_GenericReply,		"AT+CPMS"		,0x00,0x00,ID_SetMemoryType	 },
 {ATGEN_ReplyGetSMSStatus,	"AT+CPMS"		,0x00,0x00,ID_GetSMSStatus	 },
 {ATGEN_ReplyGetSMSMemories,	"AT+CPMS=?"		,0x00,0x00,ID_GetSMSMemories	 },
+{ATGEN_ReplyGetSMSLocationRange,	"AT+CMGD=?"		,0x00,0x00,ID_GetSMSLocationRange },
 {ATGEN_ReplyAddSMSMessage,	"AT+CMGW"		,0x00,0x00,ID_SaveSMSMessage	 },
 {ATGEN_GenericReply,		"AT+CSMP"		,0x00,0x00,ID_SetSMSParameters	 },
 {ATGEN_GenericReply,		"AT+CSCA"		,0x00,0x00,ID_SetSMSC		 },

--- a/libgammu/phone/at/atgen.h
+++ b/libgammu/phone/at/atgen.h
@@ -403,6 +403,24 @@ typedef struct {
 	 */
 	GSM_AT_SMS_Cache	*SMSCache;
 	/**
+	 * Bounds of physical SMS locations reported as supported by AT+CMGD=?.
+	 */
+	int			SMSLocationFirst;
+	int			SMSLocationLast;
+	int			SMSLocationPos;
+	/**
+	 * Number of messages expected when scanning the current memory started.
+	 */
+	int			SMSLocationTarget;
+	/**
+	 * Memory represented by the location bounds, or MEM_INVALID when not queried.
+	 */
+	GSM_MemoryType		SMSLocationMemory;
+	/**
+	 * Whether the location range query failed and legacy scanning should be used.
+	 */
+	gboolean			SMSLocationLegacy;
+	/**
 	 * Which folder do we read SMS from.
 	 */
 	int			SMSReadFolder;

--- a/tests/atgen/CMakeLists.txt
+++ b/tests/atgen/CMakeLists.txt
@@ -50,6 +50,7 @@ atgen_test(test-reply-get-cnmi)
 atgen_test(get-sms-location)
 atgen_test(get-sms)
 atgen_test(get-sms-text-fallback)
+atgen_test(get-next-sms-locations)
 
 if (HAVE_MYSQL_MYSQL_H OR LIBDBI_FOUND OR HAVE_POSTGRESQL_LIBPQ_FE_H OR ODBC_FOUND)
 smsd_test(test_sql_time)

--- a/tests/atgen/get-next-sms-locations.c
+++ b/tests/atgen/get-next-sms-locations.c
@@ -1,0 +1,688 @@
+#include <assert.h>
+#include <gammu-message.h>
+
+#include "test_helper.h"
+
+#include "../../libgammu/gsmstate.h"
+
+GSM_Error ATGEN_GetNextSMS(GSM_StateMachine *s, GSM_MultiSMSMessage *sms, gboolean start);
+
+static const char *sms_pdu =
+	"07918497483252F0040B918496445078F700007121320144744004D4F29C0E\r";
+
+static void setup_sms_memory(GSM_Phone_ATGENData *Priv, GSM_MemoryType memory)
+{
+	Priv->SIMSMSMemory = memory == MEM_SM ? AT_AVAILABLE : AT_NOTAVAILABLE;
+	Priv->PhoneSMSMemory = memory == MEM_ME ? AT_AVAILABLE : AT_NOTAVAILABLE;
+	Priv->SRSMSMemory = AT_NOTAVAILABLE;
+	Priv->SIMSaveSMS = AT_NOTAVAILABLE;
+	Priv->PhoneSaveSMS = AT_NOTAVAILABLE;
+	Priv->SMSMemory = memory;
+	Priv->SMSMemoryWrite = FALSE;
+	Priv->NumFolders = 1;
+}
+
+static void cleanup_sms_locations(GSM_StateMachine *s)
+{
+	cleanup_state_machine(s);
+}
+
+static void supported_range_stops_at_reported_count(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,5000\r",
+		"OK\r\n",
+		/* AT+CMGD=? */
+		"+CMGD: (1-5000),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+		/* Status refresh for the second GetNextSMS call. */
+		"+CPMS: 1,5000\r",
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	error = ATGEN_GetNextSMS(s, &sms, FALSE);
+	test_result(error == ERR_EMPTY);
+	test_result(strcmp((const char *)last_command(), "AT+CPMS=\"SM\"\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void shrinking_live_count_does_not_stop_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Initial status before reading two messages. */
+		"+CPMS: 2,30\r",
+		"OK\r\n",
+		/* AT+CMGD=? */
+		"+CMGD: (1-30),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+		/* The caller deleted location 1 before asking for the next SMS. */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* AT+CMGR=2 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(Priv->SMSLocationTarget == 2);
+
+	error = ATGEN_GetNextSMS(s, &sms, FALSE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 2);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=2\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void supported_range_bounds_overreported_count(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 2,3\r",
+		"OK\r\n",
+		/* AT+CMGD=? */
+		"+CMGD: (1-3),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=1 */
+		"OK\r\n",
+		/* AT+CMGR=2 */
+		"+CMS ERROR: 321\r\n",
+		/* AT+CMGR=3 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+		/* Status refresh for the second GetNextSMS call. */
+		"+CPMS: 2,3\r",
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 3);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=3\r") == 0);
+
+	error = ATGEN_GetNextSMS(s, &sms, FALSE);
+	test_result(error == ERR_EMPTY);
+	test_result(strcmp((const char *)last_command(), "AT+CPMS=\"SM\"\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void zero_based_locations_are_translated(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="ME" */
+		"+CPMS: 1,10\r",
+		"OK\r\n",
+		/* AT+CMGD=? */
+		"+CMGD: (0-9),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=0 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	GSM_AddPhoneFeature(&model, F_SMS_LOCATION_0);
+	setup_sms_memory(Priv, MEM_ME);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=0\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void inconsistent_cmgl_uses_location_bounds(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Initial status used by ATGEN_GetSMSList. */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* AT+CMGL=4 returns no messages despite CPMS reporting one. */
+		"OK\r\n",
+		/* Status refresh before querying location bounds. */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* AT+CMGD=? */
+		"+CMGD: (7),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=7 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 7);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=7\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void cmgl_over_cpms_count_keeps_cache(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Initial status used by ATGEN_GetSMSList. */
+		"+CPMS: 0,30\r",
+		"OK\r\n",
+		/* AT+CMGL=4 returns a message despite CPMS reporting none. */
+		"+CMGL: 7,0,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == 7);
+	test_result(Priv->SMSCount == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGL=4\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void locations_switch_from_sim_to_phone(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Status for both memories. */
+		"+CPMS: 0,10\r",
+		"OK\r\n",
+		"+CPMS: 1,5000\r",
+		"OK\r\n",
+		/* Enumerate the supported ME range. */
+		"+CMGD: (4-5),(0-4)\r",
+		"OK\r\n",
+		/* AT+CMGR=4 */
+		"+CMS ERROR: 321\r\n",
+		/* AT+CMGR=5 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	Priv->SIMSMSMemory = AT_AVAILABLE;
+	Priv->PhoneSMSMemory = AT_AVAILABLE;
+	Priv->SRSMSMemory = AT_NOTAVAILABLE;
+	Priv->SIMSaveSMS = AT_NOTAVAILABLE;
+	Priv->PhoneSaveSMS = AT_NOTAVAILABLE;
+	Priv->SMSMemory = MEM_ME;
+	Priv->SMSMemoryWrite = FALSE;
+	Priv->NumFolders = 2;
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == GSM_PHONE_MAXSMSINFOLDER + 5);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=5\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void malformed_location_bounds_use_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* Malformed AT+CMGD=? response. */
+		"+CMGD: (4-1),(0-4)\r",
+		"OK\r\n",
+		/* Legacy AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(Priv->SMSLocationLegacy);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void empty_location_bounds_use_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* Empty AT+CMGD=? capability range. */
+		"+CMGD: (),(0-4)\r",
+		"OK\r\n",
+		/* Legacy AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(Priv->SMSLocationLegacy);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void unsupported_location_bounds_use_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* Unsupported AT+CMGD=? command. */
+		"ERROR\r\n",
+		/* Legacy AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+	/* Legacy scanning must not honor stale memory from a previous result. */
+	sms.SMS[0].Memory = MEM_ME;
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(Priv->SMSLocationLegacy);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void cms_operation_not_allowed_uses_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* AT+CMGD=? is not allowed. */
+		"+CMS ERROR: 302\r\n",
+		/* Legacy AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(Priv->SMSLocationLegacy);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void cme_operation_not_allowed_uses_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* AT+CMGD=? is not allowed. */
+		"+CME ERROR: 3\r\n",
+		/* Legacy AT+CMGR=1 */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(Priv->SMSLocationLegacy);
+	test_result(sms.SMS[0].Location == 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=1\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void sim_security_error_does_not_use_legacy_scan(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* AT+CPMS="SM" */
+		"+CPMS: 1,30\r",
+		"OK\r\n",
+		/* SIM PIN required. */
+		"+CMS ERROR: 311\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	setup_sms_memory(Priv, MEM_SM);
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_SECURITYERROR);
+	test_result(!Priv->SMSLocationLegacy);
+	test_result(strcmp((const char *)last_command(), "AT+CMGD=?\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void smsme900_phone_bounds_are_normalized(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Status for both memories. */
+		"+CPMS: 0,30\r",
+		"OK\r\n",
+		"+CPMS: 1,100\r",
+		"OK\r\n",
+		/* ME reports its physical 900-based range. */
+		"+CMGD: (900-999),(0-4)\r",
+		"OK\r\n",
+		/* The logical first ME location must be read as physical index 900. */
+		"+CMGR: 1,\"\",23\r",
+		sms_pdu,
+		"OK\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	GSM_AddPhoneFeature(&model, F_SMSME900);
+	Priv->SIMSMSMemory = AT_AVAILABLE;
+	Priv->PhoneSMSMemory = AT_AVAILABLE;
+	Priv->SRSMSMemory = AT_NOTAVAILABLE;
+	Priv->SIMSaveSMS = AT_NOTAVAILABLE;
+	Priv->PhoneSaveSMS = AT_NOTAVAILABLE;
+	Priv->SMSMemory = MEM_ME;
+	Priv->SMSMemoryWrite = FALSE;
+	Priv->NumFolders = 2;
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_NONE);
+	test_result(sms.SMS[0].Location == GSM_PHONE_MAXSMSINFOLDER + 1);
+	test_result(strcmp((const char *)last_command(), "AT+CMGR=900\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+static void motorola_phone_bounds_use_mt(void)
+{
+	GSM_Error error;
+	GSM_MultiSMSMessage sms;
+	GSM_PhoneModel model;
+	GSM_StateMachine *s = setup_state_machine();
+	GSM_Phone_ATGENData *Priv = setup_at_engine(s);
+	const char *responses[] = {
+		/* Status for both memories. */
+		"+CPMS: 1,10\r",
+		"OK\r\n",
+		"+CPMS: 1,10\r",
+		"OK\r\n",
+		/* Select SM, then exhaust its supported range. */
+		"OK\r\n",
+		"+CMGD: (1),(0-4)\r",
+		"OK\r\n",
+		"+CMS ERROR: 321\r\n",
+		/* Reject phone selection so its MT alias remains the last command. */
+		"+CMS ERROR: 311\r\n",
+
+		"ERROR\r\n"
+	};
+
+	puts(__func__);
+	model = *s->Phone.Data.ModelInfo;
+	s->Phone.Data.ModelInfo = &model;
+	GSM_AddPhoneFeature(&model, F_DISABLE_CMGL);
+	Priv->SIMSMSMemory = AT_AVAILABLE;
+	Priv->PhoneSMSMemory = AT_AVAILABLE;
+	Priv->SRSMSMemory = AT_NOTAVAILABLE;
+	Priv->SIMSaveSMS = AT_NOTAVAILABLE;
+	Priv->PhoneSaveSMS = AT_NOTAVAILABLE;
+	Priv->SMSMemory = MEM_ME;
+	Priv->SMSMemoryWrite = FALSE;
+	Priv->MotorolaSMS = TRUE;
+	Priv->NumFolders = 2;
+	SET_RESPONSES(responses);
+	bind_response_handling(s);
+	memset(&sms, 0, sizeof(sms));
+
+	error = ATGEN_GetNextSMS(s, &sms, TRUE);
+	test_result(error == ERR_SECURITYERROR);
+	test_result(!Priv->SMSLocationLegacy);
+	test_result(strcmp((const char *)last_command(), "AT+CPMS=\"MT\"\r") == 0);
+
+	cleanup_sms_locations(s);
+}
+
+int main(void)
+{
+	supported_range_stops_at_reported_count();
+	shrinking_live_count_does_not_stop_scan();
+	supported_range_bounds_overreported_count();
+	zero_based_locations_are_translated();
+	inconsistent_cmgl_uses_location_bounds();
+	cmgl_over_cpms_count_keeps_cache();
+	locations_switch_from_sim_to_phone();
+	malformed_location_bounds_use_legacy_scan();
+	empty_location_bounds_use_legacy_scan();
+	unsupported_location_bounds_use_legacy_scan();
+	cms_operation_not_allowed_uses_legacy_scan();
+	cme_operation_not_allowed_uses_legacy_scan();
+	sim_security_error_does_not_use_legacy_scan();
+	smsme900_phone_bounds_are_normalized();
+	motorola_phone_bounds_use_mt();
+}


### PR DESCRIPTION
Use the modem's reported location ranges when message listings or counts are unreliable, preventing unbounded invalid-slot scans while retaining the legacy fallback and vendor storage aliases.

Closes #590

Closes #394

Closes #317