### PR TITLE
fix(smsd): expose message metadata to RunOn hooks

### DIFF
--- a/docs/man/gammu-smsd-run.7
+++ b/docs/man/gammu-smsd-run.7
@@ -83,7 +83,8 @@ Added in version 1.38.2.
 
 .sp
 Value of \fBPhoneID\fP \%<#\:option-PhoneID>\&. Useful when running multiple instances
-(see Multiple modems \%<#\:smsd-multi>).
+(see Multiple modems \%<#\:smsd-multi>). This variable is available to all \fBRunOn\fP
+directives, including calls which do not provide message details.
 .UNINDENT
 .SS Per message variables
 .sp
@@ -111,6 +112,41 @@ Added in version 1.38.5.
 
 .sp
 Message Reference. If delivery status received, this variable contains TPMR of original message
+.UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_SENT_ID
+For a delivery report matched by a database backend, the ID of the
+corresponding row in the \fBsentitems\fP table. The value is empty for other
+messages, when no matching sent message was found, and for non\-database
+backends.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_TIMESTAMP
+Message date and time as seconds since the Unix epoch. For a received
+message this is the service center timestamp. For a delivery report this is
+the time when the service center received the original message. The value
+is empty when the message does not contain a valid date and time.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_DATETIME
+The same value as \fBSMS_1_TIMESTAMP\fP, formatted as ISO 8601 with a
+timezone offset, for example \fB2024\-01\-02T03:04:05+01:30\fP\&.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_SMSC_TIMESTAMP
+For a delivery report, the discharge time as seconds since the Unix epoch.
+The value is empty for other messages or when the report does not contain a
+valid discharge time.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B SMS_1_SMSC_DATETIME
+The same value as \fBSMS_1_SMSC_TIMESTAMP\fP, formatted as ISO 8601
+with a timezone offset.
 .UNINDENT
 .SS Per part variables
 .sp

--- a/docs/man/gammu-smsdrc.5
+++ b/docs/man/gammu-smsdrc.5
@@ -495,7 +495,8 @@ message ID, which indicates an error while sending the message.
 \fBNote:\fP
 .INDENT 7.0
 .INDENT 3.5
-The environment with message (as is in \fBRunOnReceive\fP) is not passed to the command.
+Message details from \fBRunOnReceive\fP are not passed
+to the command. The \fBPHONE_ID\fP \%<#\:envvar-PHONE_ID> variable is still available.
 .UNINDENT
 .UNINDENT
 .UNINDENT
@@ -520,7 +521,8 @@ Added in version 1.38.5.
 Executes a program after cancelling incoming call.
 .sp
 The program will receive a literal argument containing the phone number of
-the call. This requires \fBHangupCalls\fP to be enabled.
+the call. The \fBPHONE_ID\fP \%<#\:envvar-PHONE_ID> variable identifies the receiving SMSD
+instance. This requires \fBHangupCalls\fP to be enabled.
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/docs/manual/smsd/code.rst
+++ b/docs/manual/smsd/code.rst
@@ -39,13 +39,15 @@ in ``GSM_SMSDService`` structure:
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::SaveInboxSMS       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char **Locations)
+.. c:function:: GSM_Error	GSM_SMSDService::SaveInboxSMS       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs)
 
     Saves message into inbox.
 
     :param sms: Message data to save
     :param Config: Pointer to SMSD configuration data
-    :param Locations: Newly allocation pointer to string with IDs identifying saved messages.
+    :param Locations: Array with IDs identifying saved messages.
+    :param SentIDs: Per-message array with IDs of sent messages matched to
+        delivery reports.
     :return: Error code.
 
 .. c:function:: GSM_Error	GSM_SMSDService::FindOutboxSMS      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID)

--- a/docs/manual/smsd/config.rst
+++ b/docs/manual/smsd/config.rst
@@ -386,7 +386,8 @@ General parameters of SMS daemon
     be either ``INIT`` (meaning failure during phone initialization) or a
     message ID, which indicates an error while sending the message.
 
-    .. note:: The environment with message (as is in :config:option:`RunOnReceive`) is not passed to the command.
+    .. note:: Message details from :config:option:`RunOnReceive` are not passed
+        to the command. The :envvar:`PHONE_ID` variable is still available.
 
 .. config:option:: RunOnSent
 
@@ -405,7 +406,8 @@ General parameters of SMS daemon
     Executes a program after cancelling incoming call.
 
     The program will receive a literal argument containing the phone number of
-    the call. This requires :config:option:`HangupCalls` to be enabled.
+    the call. The :envvar:`PHONE_ID` variable identifies the receiving SMSD
+    instance. This requires :config:option:`HangupCalls` to be enabled.
 
 .. config:option:: IncludeNumbersFile
 

--- a/docs/manual/smsd/run.rst
+++ b/docs/manual/smsd/run.rst
@@ -53,7 +53,8 @@ Global variables
     .. versionadded:: 1.38.2
 
     Value of :config:option:`PhoneID`. Useful when running multiple instances
-    (see :ref:`smsd-multi`).
+    (see :ref:`smsd-multi`). This variable is available to all ``RunOn``
+    directives, including calls which do not provide message details.
 
 Per message variables
 +++++++++++++++++++++
@@ -78,6 +79,36 @@ message, where 1 is replaced by current number of message.
     .. versionadded:: 1.38.5
 
     Message Reference. If delivery status received, this variable contains TPMR of original message
+
+.. envvar:: SMS_1_SENT_ID
+
+    For a delivery report matched by a database backend, the ID of the
+    corresponding row in the ``sentitems`` table. The value is empty for other
+    messages, when no matching sent message was found, and for non-database
+    backends.
+
+.. envvar:: SMS_1_TIMESTAMP
+
+    Message date and time as seconds since the Unix epoch. For a received
+    message this is the service center timestamp. For a delivery report this is
+    the time when the service center received the original message. The value
+    is empty when the message does not contain a valid date and time.
+
+.. envvar:: SMS_1_DATETIME
+
+    The same value as :envvar:`SMS_1_TIMESTAMP`, formatted as ISO 8601 with a
+    timezone offset, for example ``2024-01-02T03:04:05+01:30``.
+
+.. envvar:: SMS_1_SMSC_TIMESTAMP
+
+    For a delivery report, the discharge time as seconds since the Unix epoch.
+    The value is empty for other messages or when the report does not contain a
+    valid discharge time.
+
+.. envvar:: SMS_1_SMSC_DATETIME
+
+    The same value as :envvar:`SMS_1_SMSC_TIMESTAMP`, formatted as ISO 8601
+    with a timezone offset.
 
 Per part variables
 ++++++++++++++++++

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1145,25 +1145,143 @@ char *SMSD_RunOnCommand(const char *command, const GSM_StringArray *arguments)
 }
 
 #ifdef WIN32
-#define setenv(var, value, force) SetEnvironmentVariable(var, value)
+#define setenv(var, value, force) SetEnvironmentVariableA(var, value)
 #endif
 
 /**
- * Fills in environment with information about messages.
+ * Fills in environment with date and time information about a message.
  */
-void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config)
+static void SMSD_RunOnDateTimeEnvironment(int index, const char *prefix, GSM_DateTime datetime)
+{
+	char datetime_buffer[100], name[100], timestamp_buffer[100];
+	char timezone_sign;
+	int written;
+	long long timezone;
+	time_t timestamp;
+
+	snprintf(name, sizeof(name), "SMS_%d_%sTIMESTAMP", index, prefix);
+	setenv(name, "", 1);
+	snprintf(name, sizeof(name), "SMS_%d_%sDATETIME", index, prefix);
+	setenv(name, "", 1);
+
+	if (datetime.Year < 1 || datetime.Hour < 0 || datetime.Minute < 0 ||
+	    datetime.Second < 0 || !CheckDate(&datetime) || !CheckTime(&datetime)) {
+		return;
+	}
+
+	timestamp = Fill_Time_T(datetime);
+	if (timestamp != (time_t)-1) {
+		snprintf(timestamp_buffer, sizeof(timestamp_buffer), "%lld", (long long)timestamp);
+		snprintf(name, sizeof(name), "SMS_%d_%sTIMESTAMP", index, prefix);
+		setenv(name, timestamp_buffer, 1);
+	}
+
+	timezone = datetime.Timezone;
+	if (timezone < 0) {
+		timezone_sign = '-';
+		timezone = -timezone;
+	} else {
+		timezone_sign = '+';
+	}
+	written = snprintf(datetime_buffer, sizeof(datetime_buffer),
+		"%04d-%02d-%02dT%02d:%02d:%02d%c%02lld:%02lld",
+		datetime.Year, datetime.Month, datetime.Day,
+		datetime.Hour, datetime.Minute, datetime.Second,
+		timezone_sign, timezone / 3600, (timezone % 3600) / 60);
+	if (written < 0 || (size_t)written >= sizeof(datetime_buffer)) {
+		return;
+	}
+	snprintf(name, sizeof(name), "SMS_%d_%sDATETIME", index, prefix);
+	setenv(name, datetime_buffer, 1);
+}
+
+/**
+ * Reads a previous RunOn item count from the inherited environment.
+ */
+static int SMSD_RunOnEnvironmentCount(const char *name)
+{
+	const char *value;
+	char *end;
+	long count;
+#ifdef WIN32
+	char value_buffer[100];
+	DWORD length;
+
+	length = GetEnvironmentVariableA(name, value_buffer, sizeof(value_buffer));
+	if (length == 0 || length >= sizeof(value_buffer)) {
+		return 0;
+	}
+	value = value_buffer;
+#else
+	value = getenv(name);
+#endif
+	if (value == NULL || *value == 0) {
+		return 0;
+	}
+
+	count = strtol(value, &end, 10);
+	if (*end != 0 || count < 1) {
+		return 0;
+	}
+	if (count > GSM_MAX_MULTI_SMS) {
+		return GSM_MAX_MULTI_SMS;
+	}
+	return (int)count;
+}
+
+/**
+ * Clears message data left by an earlier RunOn hook.
+ */
+static void SMSD_ClearRunOnEnvironment(void)
+{
+	static const char *message_names[] = {
+		"CLASS", "REFERENCE", "NUMBER", "TEXT", "SENT_ID",
+		"TIMESTAMP", "DATETIME", "SMSC_TIMESTAMP", "SMSC_DATETIME"
+	};
+	static const char *decoded_names[] = {
+		"TEXT", "MMS_SENDER", "MMS_TITLE", "MMS_ADDRESS", "MMS_SIZE"
+	};
+	char name[100];
+	int i;
+	size_t j;
+
+	for (i = 1; i <= SMSD_RunOnEnvironmentCount("SMS_MESSAGES"); i++) {
+		for (j = 0; j < sizeof(message_names) / sizeof(message_names[0]); j++) {
+			snprintf(name, sizeof(name), "SMS_%d_%s", i, message_names[j]);
+			setenv(name, "", 1);
+		}
+	}
+	for (i = 1; i <= SMSD_RunOnEnvironmentCount("DECODED_PARTS"); i++) {
+		for (j = 0; j < sizeof(decoded_names) / sizeof(decoded_names[0]); j++) {
+			snprintf(name, sizeof(name), "DECODED_%d_%s", i, decoded_names[j]);
+			setenv(name, "", 1);
+		}
+	}
+}
+
+/**
+ * Fills in environment with information for RunOn hooks.
+ */
+void SMSD_RunOnEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *SentIDs, gboolean is_receive)
 {
 	GSM_MultiPartSMSInfo SMSInfo;
+	GSM_DateTime empty_datetime;
 	char buffer[100], name[100];
 	int i;
+
+	memset(&empty_datetime, 0, sizeof(empty_datetime));
+	SMSD_ClearRunOnEnvironment();
+	setenv("PHONE_ID", Config->PhoneID == NULL ? "" : Config->PhoneID, 1);
+
+	if (sms == NULL) {
+		setenv("SMS_MESSAGES", "0", 1);
+		setenv("DECODED_PARTS", "0", 1);
+		return;
+	}
 
 	/* Raw message data */
 	sprintf(buffer, "%d", sms->Number);
 	setenv("SMS_MESSAGES", buffer, 1);
-
-	if (Config->PhoneID) {
-		setenv("PHONE_ID", Config->PhoneID, 1);
-	}
 
 	for (i = 0; i < sms->Number; i++) {
 		sprintf(buffer, "%d", sms->SMS[i].Class);
@@ -1174,9 +1292,24 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
 		setenv(name, buffer, 1);
 		sprintf(name, "SMS_%d_NUMBER", i + 1);
 		setenv(name, DecodeUnicodeConsole(sms->SMS[i].Number), 1);
+		sprintf(name, "SMS_%d_TEXT", i + 1);
+		setenv(name, "", 1);
 		if (sms->SMS[i].Coding != SMS_Coding_8bit && sms->SMS[i].UDH.Type != UDH_UserUDH) {
-			sprintf(name, "SMS_%d_TEXT", i + 1);
 			setenv(name, DecodeUnicodeConsole(sms->SMS[i].Text), 1);
+		}
+
+		sprintf(name, "SMS_%d_SENT_ID", i + 1);
+		setenv(name, "", 1);
+		if (SentIDs != NULL && (size_t)i < SentIDs->used &&
+		    is_receive && sms->SMS[i].PDU == SMS_Status_Report) {
+			setenv(name, SentIDs->data[i], 1);
+		}
+
+		SMSD_RunOnDateTimeEnvironment(i + 1, "", sms->SMS[i].DateTime);
+		if (is_receive && sms->SMS[i].PDU == SMS_Status_Report) {
+			SMSD_RunOnDateTimeEnvironment(i + 1, "SMSC_", sms->SMS[i].SMSCTime);
+		} else {
+			SMSD_RunOnDateTimeEnvironment(i + 1, "SMSC_", empty_datetime);
 		}
 	}
 
@@ -1185,6 +1318,16 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
 		sprintf(buffer, "%d", SMSInfo.EntriesNum);
 		setenv("DECODED_PARTS", buffer, 1);
 		for (i = 0; i < SMSInfo.EntriesNum; i++) {
+			sprintf(name, "DECODED_%d_TEXT", i + 1);
+			setenv(name, "", 1);
+			sprintf(name, "DECODED_%d_MMS_SENDER", i + 1);
+			setenv(name, "", 1);
+			sprintf(name, "DECODED_%d_MMS_TITLE", i + 1);
+			setenv(name, "", 1);
+			sprintf(name, "DECODED_%d_MMS_ADDRESS", i + 1);
+			setenv(name, "", 1);
+			sprintf(name, "DECODED_%d_MMS_SIZE", i + 1);
+			setenv(name, "", 1);
 			switch (SMSInfo.Entries[i].ID) {
 				case SMS_ConcatenatedTextLong:
 				case SMS_ConcatenatedAutoTextLong:
@@ -1224,7 +1367,7 @@ void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Conf
  *
  * This is Windows variant.
  */
-gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event)
+gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const GSM_StringArray *SentIDs, const char *event)
 {
 	BOOL ret;
 	STARTUPINFO si;
@@ -1238,9 +1381,7 @@ gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfi
 	}
 
 	/* Prepare environment */
-	if (sms != NULL) {
-		SMSD_RunOnReceiveEnvironment(sms, Config);
-	}
+	SMSD_RunOnEnvironment(sms, Config, SentIDs, event != NULL && strcmp(event, "receive") == 0);
 
 	ZeroMemory(&si, sizeof(si));
 	si.cb = sizeof(si);
@@ -1275,7 +1416,7 @@ gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfi
  *
  * This is POSIX variant.
  */
-gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event)
+gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const GSM_StringArray *SentIDs, const char *event)
 {
 	int pid;
 	int pipefd[2];
@@ -1364,9 +1505,7 @@ out:
 	close(pipefd[0]);
 
 	/* Prepare environment */
-	if (sms != NULL) {
-		SMSD_RunOnReceiveEnvironment(sms, Config);
-	}
+	SMSD_RunOnEnvironment(sms, Config, SentIDs, event != NULL && strcmp(event, "receive") == 0);
 
 	/* Calculate command line */
 	cmdline = SMSD_RunOnCommand(command, arguments);
@@ -1420,7 +1559,7 @@ static gboolean SMSD_RunOnSingle(const char *command, GSM_MultiSMSMessage *sms, 
 		return FALSE;
 	}
 
-	result = SMSD_RunOn(command, sms, Config, &arguments, event);
+	result = SMSD_RunOn(command, sms, Config, &arguments, NULL, event);
 	GSM_StringArray_Free(&arguments);
 	return result;
 }
@@ -1506,18 +1645,21 @@ GSM_Error SMSD_ProcessSMS(GSM_SMSDConfig *Config, GSM_MultiSMSMessage *sms)
 {
 	GSM_Error error = ERR_NONE;
 	GSM_StringArray locations;
+	GSM_StringArray sent_ids;
 
 	GSM_StringArray_New(&locations);
+	GSM_StringArray_New(&sent_ids);
 	/* Increase message counter */
 	Config->Status->Received += sms->Number;
 	/* Send message to the backend */
-	error = Config->Service->SaveInboxSMS(sms, Config, &locations);
+	error = Config->Service->SaveInboxSMS(sms, Config, &locations, &sent_ids);
 	/* RunOnReceive handling */
 	if (Config->RunOnReceive != NULL && error == ERR_NONE) {
-		SMSD_RunOn(Config->RunOnReceive, sms, Config, &locations, "receive");
+		SMSD_RunOn(Config->RunOnReceive, sms, Config, &locations, &sent_ids, "receive");
 	}
 	/* Free memory allocated by SaveInboxSMS */
 	GSM_StringArray_Free(&locations);
+	GSM_StringArray_Free(&sent_ids);
 	return error;
 }
 

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -44,7 +44,7 @@ typedef struct {
 	GSM_Error	(*Init) 	      (GSM_SMSDConfig *Config);
 	GSM_Error	(*Free) 	      (GSM_SMSDConfig *Config);
 	GSM_Error	(*InitAfterConnect)   (GSM_SMSDConfig *Config);
-	GSM_Error	(*SaveInboxSMS)       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations);
+	GSM_Error	(*SaveInboxSMS)       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs);
 	GSM_Error	(*FindOutboxSMS)      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID);
 	GSM_Error	(*MoveSMS)  	      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, gboolean alwaysDelete, gboolean sent);
 	GSM_Error	(*CreateOutboxSMS)    (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *NewID);
@@ -61,6 +61,8 @@ typedef struct {
 	 */
 	GSM_Error	(*ReadConfiguration) (GSM_SMSDConfig *Config);
 } GSM_SMSDService;
+
+void SMSD_RunOnEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *SentIDs, gboolean is_receive);
 
 struct _GSM_SMSDConfig {
 	const char	*ServiceName;

--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -99,7 +99,7 @@ static GSM_Error SMSDFiles_BuildPath(char *result, size_t result_size,
 }
 
 /* Save SMS from phone (called Inbox sms - it's in phone Inbox) somewhere */
-static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations)
+static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs)
 {
 	GSM_Error error = ERR_NONE;
 	int i, j;
@@ -110,6 +110,14 @@ static GSM_Error SMSDFiles_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfi
 #ifdef GSM_ENABLE_BACKUP
 	GSM_SMS_Backup *backup;
 #endif
+
+	if (SentIDs != NULL) {
+		for (i = 0; i < sms->Number; i++) {
+			if (!GSM_StringArray_Add(SentIDs, "")) {
+				return ERR_MOREMEMORY;
+			}
+		}
+	}
 
 	j = 0;
 	done = FALSE;

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -707,7 +707,7 @@ static GSM_Error SMSDSQL_InitAfterConnect(GSM_SMSDConfig * Config)
 }
 
 /* Save SMS from phone (called Inbox sms - it's in phone Inbox) somewhere */
-static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations)
+static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig * Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs)
 {
 	SQL_result res, res2;
 	SQL_Var vars[3];
@@ -725,10 +725,12 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 	unsigned long long new_id, sent_id;
 	const char *state, *smsc;
 	char location[50];
+	char sent_id_string[50];
 
 	sms->Processed = FALSE;
 
 	for (i = 0; i < sms->Number; i++) {
+		sent_id_string[0] = 0;
 		EncodeUTF8(destinationnumber, sms->SMS[i].Number);
 		EncodeUTF8(smsc_message, sms->SMS[i].SMSC.Number);
 		if (sms->SMS[i].PDU == SMS_Status_Report) {
@@ -805,15 +807,23 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 					return error;
 				}
 				db->FreeResult(Config, &res2);
+				snprintf(sent_id_string, sizeof(sent_id_string), "%llu", sent_id);
 			} else {
 				SMSD_Log(DEBUG_ERROR, Config, "Failed to find SMS for TPMR=%i, Number=%s", sms->SMS[i].MessageReference, destinationnumber);
 			}
 			db->FreeResult(Config, &res);
+			if (SentIDs != NULL && !GSM_StringArray_Add(SentIDs, sent_id_string)) {
+				return ERR_MOREMEMORY;
+			}
 			continue;
 		}
 
-		if (sms->SMS[i].PDU != SMS_Deliver)
+		if (sms->SMS[i].PDU != SMS_Deliver) {
+			if (SentIDs != NULL && !GSM_StringArray_Add(SentIDs, "")) {
+				return ERR_MOREMEMORY;
+			}
 			continue;
+		}
 
 		error = SMSDSQL_NamedQuery(Config, Config->SMSDSQL_queries[SQL_QUERY_SAVE_INBOX_SMS_INSERT], &sms->SMS[i], sms, NULL, &res, FALSE);
 		if (error != ERR_NONE) {
@@ -849,6 +859,9 @@ static GSM_Error SMSDSQL_SaveInboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConfig 
 		}
 		db->FreeResult(Config, &res2);
 
+		if (SentIDs != NULL && !GSM_StringArray_Add(SentIDs, "")) {
+			return ERR_MOREMEMORY;
+		}
 	}
 
 	return ERR_NONE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1245,6 +1245,11 @@ add_coverage(smsd-run-command)
 target_link_libraries(smsd-run-command libGammu ${LIBINTL_LIBRARIES} gsmsd)
 add_test(smsd-run-command "${GAMMU_TEST_PATH}/smsd-run-command${CMAKE_EXECUTABLE_SUFFIX}")
 
+add_executable(smsd-run-environment smsd-run-environment.c)
+add_coverage(smsd-run-environment)
+target_link_libraries(smsd-run-environment libGammu ${LIBINTL_LIBRARIES} gsmsd)
+add_test(smsd-run-environment "${GAMMU_TEST_PATH}/smsd-run-environment${CMAKE_EXECUTABLE_SUFFIX}")
+
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/smsd-files-inbox")
 add_executable(smsd-files-backend smsd-files-backend.c)
 add_coverage(smsd-files-backend)

--- a/tests/sms-at-parse.c
+++ b/tests/sms-at-parse.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include "../libgammu/misc/array.h"
 #include "../libgammu/protocol/protocol.h"	/* Needed for GSM_Protocol_Message */
 #include "../libgammu/gsmstate.h"	/* Needed for state machine internals */
 #include "../libgammu/gsmphones.h"	/* Phone data */
@@ -14,8 +15,7 @@
 #include "common.h"
 
 extern GSM_Error ATGEN_ReplyGetSMSMessage(GSM_Protocol_Message *msg, GSM_StateMachine * s);
-extern void SMSD_RunOnReceiveEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config);
-
+extern void SMSD_RunOnEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *SentIDs, gboolean is_receive);
 #define BUFFER_SIZE 16384
 
 int main(int argc, char **argv)
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 		DisplayMultiSMSInfo(&sms, TRUE, TRUE, NULL, NULL);
 		printf("Parts: %d, count: %d, ID16: %d, ID8: %d\n", sms.SMS[0].UDH.AllParts, sms.Number, sms.SMS[0].UDH.ID16bit, sms.SMS[0].UDH.ID8bit);
 
-		SMSD_RunOnReceiveEnvironment(&sms, smsd);
+		SMSD_RunOnEnvironment(&sms, smsd, NULL, TRUE);
 	}
 
 	/* This is normally done by ATGEN_Terminate */

--- a/tests/smsd-files-backend.c
+++ b/tests/smsd-files-backend.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
 	EncodeUnicode(sms.SMS[0].Number, "123", 3);
 	memcpy(sms.SMS[0].Text, expected + 2, sizeof(expected) - 2);
 
-	error = SMSDFiles.SaveInboxSMS(&sms, &config, &locations);
+	error = SMSDFiles.SaveInboxSMS(&sms, &config, &locations, NULL);
 	if (error != ERR_NONE) {
 		fprintf(stderr, "Failed to save inbox message: %s\n", GSM_ErrorString(error));
 		result = 1;

--- a/tests/smsd-run-environment.c
+++ b/tests/smsd-run-environment.c
@@ -1,0 +1,137 @@
+#include <gammu.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
+
+#include "../libgammu/misc/array.h"
+#include "../smsd/core.h"
+#include "common.h"
+
+static void check_environment(const char *name, const char *expected)
+{
+#ifdef WIN32
+	char actual_buffer[100];
+	DWORD length;
+	const char *actual;
+
+	actual_buffer[0] = 0;
+	SetLastError(ERROR_SUCCESS);
+	length = GetEnvironmentVariableA(name, actual_buffer, sizeof(actual_buffer));
+	if (length >= sizeof(actual_buffer) ||
+	    (length == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND)) {
+		actual = NULL;
+	} else {
+		actual = actual_buffer;
+	}
+#else
+	const char *actual = getenv(name);
+#endif
+
+	if (actual == NULL || strcmp(actual, expected) != 0) {
+		fprintf(stderr, "Environment mismatch for %s:\nexpected: %s\nactual: %s\n",
+			name, expected, actual == NULL ? "(unset)" : actual);
+		exit(2);
+	}
+}
+
+static void set_test_environment(const char *name, const char *value)
+{
+#ifdef WIN32
+	if (!SetEnvironmentVariableA(name, value)) {
+#else
+	if (setenv(name, value, 1) != 0) {
+#endif
+		fprintf(stderr, "Failed to set environment variable %s\n", name);
+		exit(2);
+	}
+}
+
+int main(void)
+{
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_StringArray sent_ids;
+
+	memset(&sms, 0, sizeof(sms));
+	memset(&config, 0, sizeof(config));
+	GSM_StringArray_New(&sent_ids);
+
+	config.PhoneID = "modem-a";
+	config.gsm = GSM_AllocStateMachine();
+	test_result(config.gsm != NULL);
+
+	sms.Number = 2;
+	GSM_SetDefaultSMSData(&sms.SMS[0]);
+	GSM_SetDefaultSMSData(&sms.SMS[1]);
+	sms.SMS[0].PDU = SMS_Status_Report;
+	sms.SMS[0].DateTime.Year = 2024;
+	sms.SMS[0].DateTime.Month = 1;
+	sms.SMS[0].DateTime.Day = 2;
+	sms.SMS[0].DateTime.Hour = 3;
+	sms.SMS[0].DateTime.Minute = 4;
+	sms.SMS[0].DateTime.Second = 5;
+	sms.SMS[0].DateTime.Timezone = 90 * 60;
+	sms.SMS[0].SMSCTime.Year = 2024;
+	sms.SMS[0].SMSCTime.Month = 1;
+	sms.SMS[0].SMSCTime.Day = 2;
+	sms.SMS[0].SMSCTime.Hour = 4;
+	sms.SMS[0].SMSCTime.Minute = 5;
+	sms.SMS[0].SMSCTime.Second = 6;
+	sms.SMS[0].SMSCTime.Timezone = -2 * 60 * 60;
+	sms.SMS[1].PDU = SMS_Deliver;
+	memset(&sms.SMS[1].DateTime, 0, sizeof(sms.SMS[1].DateTime));
+
+	test_result(GSM_StringArray_Add(&sent_ids, "123"));
+	test_result(GSM_StringArray_Add(&sent_ids, ""));
+
+	SMSD_RunOnEnvironment(&sms, &config, &sent_ids, TRUE);
+
+	check_environment("PHONE_ID", "modem-a");
+	check_environment("SMS_MESSAGES", "2");
+	check_environment("SMS_1_SENT_ID", "123");
+	check_environment("SMS_2_SENT_ID", "");
+	check_environment("SMS_1_TIMESTAMP", "1704159245");
+	check_environment("SMS_1_DATETIME", "2024-01-02T03:04:05+01:30");
+	check_environment("SMS_1_SMSC_TIMESTAMP", "1704175506");
+	check_environment("SMS_1_SMSC_DATETIME", "2024-01-02T04:05:06-02:00");
+	check_environment("SMS_2_TIMESTAMP", "");
+	check_environment("SMS_2_DATETIME", "");
+	check_environment("SMS_2_SMSC_TIMESTAMP", "");
+	check_environment("SMS_2_SMSC_DATETIME", "");
+
+	SMSD_RunOnEnvironment(&sms, &config, &sent_ids, FALSE);
+	check_environment("SMS_1_SENT_ID", "");
+	check_environment("SMS_1_TIMESTAMP", "1704159245");
+	check_environment("SMS_1_SMSC_TIMESTAMP", "");
+	check_environment("SMS_1_SMSC_DATETIME", "");
+
+	set_test_environment("DECODED_PARTS", "1");
+	set_test_environment("DECODED_1_TEXT", "stale");
+	set_test_environment("DECODED_1_MMS_SENDER", "stale");
+	config.PhoneID = "modem-b";
+	SMSD_RunOnEnvironment(NULL, &config, NULL, FALSE);
+	check_environment("PHONE_ID", "modem-b");
+	check_environment("SMS_MESSAGES", "0");
+	check_environment("DECODED_PARTS", "0");
+	check_environment("SMS_1_CLASS", "");
+	check_environment("SMS_1_SENT_ID", "");
+	check_environment("SMS_1_TIMESTAMP", "");
+	check_environment("SMS_1_DATETIME", "");
+	check_environment("SMS_1_SMSC_TIMESTAMP", "");
+	check_environment("SMS_1_SMSC_DATETIME", "");
+	check_environment("DECODED_1_TEXT", "");
+	check_environment("DECODED_1_MMS_SENDER", "");
+
+	GSM_StringArray_Free(&sent_ids);
+	GSM_FreeStateMachine(config.gsm);
+	return 0;
+}
+
+/* Editor configuration
+ * vim: noexpandtab sw=8 ts=8 sts=8 tw=72:
+ */

--- a/tests/smsd-run.c
+++ b/tests/smsd-run.c
@@ -6,7 +6,7 @@
 
 #include "../libgammu/misc/array.h"
 
-extern gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const char *event);
+extern gboolean SMSD_RunOn(const char *command, GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *arguments, const GSM_StringArray *SentIDs, const char *event);
 
 static gboolean add_argument(GSM_StringArray *arguments, const char *value)
 {
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, NULL, "test");
 	GSM_StringArray_Free(&arguments);
 	if (!result) {
 		fprintf(stderr, "RunOn command failed\n");
@@ -86,7 +86,7 @@ int main(int argc, char **argv)
 
 	GSM_StringArray_New(&arguments);
 	setenv("SMSD_TEST_EMPTY", "1", 1);
-	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, NULL, "test");
 	GSM_StringArray_Free(&arguments);
 	unsetenv("SMSD_TEST_EMPTY");
 	if (!result) {
@@ -102,7 +102,7 @@ int main(int argc, char **argv)
 		SMSD_FreeConfig(config);
 		return 1;
 	}
-	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, "test");
+	result = SMSD_RunOn("exec \"$SMSD_RUN_HELPER\"", NULL, config, &arguments, NULL, "test");
 	GSM_StringArray_Free(&arguments);
 	unsetenv("SMSD_TEST_SINGLE");
 	SMSD_FreeConfig(config);

--- a/tests/sql-read-order.c
+++ b/tests/sql-read-order.c
@@ -47,6 +47,7 @@ static int multipart_queries;
 static time_t delivery_time;
 static time_t outbox_insert_time;
 static gboolean delivery_update_seen;
+static gboolean delivery_select_present;
 static gboolean outbox_is_multipart;
 static gboolean sent_item_present;
 static gboolean sent_item_mismatch;
@@ -188,8 +189,9 @@ static int mock_next_row(GSM_SMSDConfig *config UNUSED, SQL_result *result)
 	switch (state->kind) {
 		case RESULT_FIND_ID:
 		case RESULT_OUTBOX_BODY:
-		case RESULT_DELIVERY_SELECT:
 			return state->row++ == 0;
+		case RESULT_DELIVERY_SELECT:
+			return delivery_select_present && state->row++ == 0;
 		case RESULT_OUTBOX_MULTIPART:
 			return multipart_queries == 1 && state->row++ == 0;
 		case RESULT_SENT_ITEM:
@@ -396,6 +398,7 @@ static void reset_mock(void)
 	delivery_fields = 0;
 	multipart_queries = 0;
 	delivery_update_seen = FALSE;
+	delivery_select_present = TRUE;
 	outbox_insert_time = 1700000000;
 	outbox_is_multipart = TRUE;
 	sent_item_present = FALSE;
@@ -591,11 +594,13 @@ static void test_delivery_report_order(void)
 {
 	GSM_SMSDConfig config;
 	GSM_MultiSMSMessage sms;
+	GSM_StringArray sent_ids;
 	GSM_Error error;
 
 	reset_mock();
 	setup_config(&config);
 	memset(&sms, 0, sizeof(sms));
+	GSM_StringArray_New(&sent_ids);
 	sms.Number = 1;
 	GSM_SetDefaultSMSData(&sms.SMS[0]);
 	sms.SMS[0].PDU = SMS_Status_Report;
@@ -604,11 +609,42 @@ static void test_delivery_report_order(void)
 	EncodeUnicode(sms.SMS[0].Text, "Delivered", strlen("Delivered"));
 	delivery_time = Fill_Time_T(sms.SMS[0].DateTime);
 
-	error = SMSDSQL.SaveInboxSMS(&sms, &config, NULL);
+	error = SMSDSQL.SaveInboxSMS(&sms, &config, NULL, &sent_ids);
 
 	test_result(error == ERR_NONE);
 	test_result(delivery_update_seen == TRUE);
 	test_result(delivery_fields == ((1ULL << 0) | (1ULL << 1) | (1ULL << 2) | (1ULL << 4)));
+	test_result(sent_ids.used == 1);
+	test_result(strcmp(sent_ids.data[0], "123") == 0);
+	GSM_StringArray_Free(&sent_ids);
+}
+
+static void test_unmatched_delivery_report_id(void)
+{
+	GSM_SMSDConfig config;
+	GSM_MultiSMSMessage sms;
+	GSM_StringArray sent_ids;
+	GSM_Error error;
+
+	reset_mock();
+	setup_config(&config);
+	memset(&sms, 0, sizeof(sms));
+	GSM_StringArray_New(&sent_ids);
+	delivery_select_present = FALSE;
+	sms.Number = 1;
+	GSM_SetDefaultSMSData(&sms.SMS[0]);
+	sms.SMS[0].PDU = SMS_Status_Report;
+	EncodeUnicode(sms.SMS[0].Number, "+420123456", strlen("+420123456"));
+	EncodeUnicode(sms.SMS[0].SMSC.Number, "+420987654", strlen("+420987654"));
+	EncodeUnicode(sms.SMS[0].Text, "Delivered", strlen("Delivered"));
+
+	error = SMSDSQL.SaveInboxSMS(&sms, &config, NULL, &sent_ids);
+
+	test_result(error == ERR_NONE);
+	test_result(delivery_update_seen == FALSE);
+	test_result(sent_ids.used == 1);
+	test_result(strcmp(sent_ids.data[0], "") == 0);
+	GSM_StringArray_Free(&sent_ids);
 }
 
 static int collision_add_calls;
@@ -761,6 +797,7 @@ int main(void)
 	test_reused_sent_item_id_is_rejected();
 	test_reconciliation_query_error_is_retryable();
 	test_delivery_report_order();
+	test_unmatched_delivery_report_id();
 	test_send_finalized_failure_is_removed();
 	test_send_collision_is_left_queued();
 	test_send_reconciliation_error_is_left_queued();


### PR DESCRIPTION
RunOn hooks lacked the database ID needed to correlate delivery reports and exposed inconsistent instance and timestamp context. Propagate matched sent-item IDs, message and SMSC timestamps, and PHONE_ID across hooks.

Closes #485

Closes #618

Closes #427