### PR TITLE
test(smsd): verify MMS RunOn environment

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -455,9 +455,22 @@ if (WITH_ATGEN)
 
     foreach(TESTMESSAGE ${MESSAGES})
         string(REPLACE .dump "" TESTNAME ${TESTMESSAGE})
-        add_test("sms-at-parse-${TESTNAME}"
-            "${GAMMU_TEST_PATH}/sms-at-parse${CMAKE_EXECUTABLE_SUFFIX}"
-            "${Gammu_SOURCE_DIR}/tests/at-sms/${TESTMESSAGE}")
+        if (TESTNAME STREQUAL "40")
+            add_test("sms-at-parse-${TESTNAME}"
+                "${GAMMU_TEST_PATH}/sms-at-parse${CMAKE_EXECUTABLE_SUFFIX}"
+                "${Gammu_SOURCE_DIR}/tests/at-sms/${TESTMESSAGE}"
+                "PDU"
+                "SMS_MESSAGES=1"
+                "DECODED_PARTS=1"
+                "DECODED_1_MMS_SENDER=+33333493211/TYPE=PLMN"
+                "DECODED_1_MMS_TITLE="
+                "DECODED_1_MMS_ADDRESS=http://mts/?id=81460494"
+                "DECODED_1_MMS_SIZE=96857")
+        else ()
+            add_test("sms-at-parse-${TESTNAME}"
+                "${GAMMU_TEST_PATH}/sms-at-parse${CMAKE_EXECUTABLE_SUFFIX}"
+                "${Gammu_SOURCE_DIR}/tests/at-sms/${TESTMESSAGE}")
+        endif ()
     endforeach(TESTMESSAGE $MESSAGES)
 
     # List test cases for TXT mode

--- a/tests/sms-at-parse.c
+++ b/tests/sms-at-parse.c
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include "../libgammu/misc/array.h"
 #include "../libgammu/protocol/protocol.h"	/* Needed for GSM_Protocol_Message */
 #include "../libgammu/gsmstate.h"	/* Needed for state machine internals */
@@ -17,6 +21,53 @@
 extern GSM_Error ATGEN_ReplyGetSMSMessage(GSM_Protocol_Message *msg, GSM_StateMachine * s);
 extern void SMSD_RunOnEnvironment(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, const GSM_StringArray *SentIDs, gboolean is_receive);
 #define BUFFER_SIZE 16384
+
+static void check_environment(const char *assignment)
+{
+	const char *separator;
+	const char *expected;
+	const char *actual;
+	char name[100];
+	size_t name_length;
+#ifdef WIN32
+	char actual_buffer[100];
+	DWORD length;
+#endif
+
+	separator = strchr(assignment, '=');
+	if (separator == NULL) {
+		fprintf(stderr, "Invalid environment expectation: %s\n", assignment);
+		exit(2);
+	}
+	name_length = separator - assignment;
+	if (name_length == 0 || name_length >= sizeof(name)) {
+		fprintf(stderr, "Invalid environment variable name: %s\n", assignment);
+		exit(2);
+	}
+	memcpy(name, assignment, name_length);
+	name[name_length] = 0;
+	expected = separator + 1;
+
+#ifdef WIN32
+	actual_buffer[0] = 0;
+	SetLastError(ERROR_SUCCESS);
+	length = GetEnvironmentVariableA(name, actual_buffer, sizeof(actual_buffer));
+	if (length >= sizeof(actual_buffer) ||
+	    (length == 0 && GetLastError() == ERROR_ENVVAR_NOT_FOUND)) {
+		actual = NULL;
+	} else {
+		actual = actual_buffer;
+	}
+#else
+	actual = getenv(name);
+#endif
+
+	if (actual == NULL || strcmp(actual, expected) != 0) {
+		fprintf(stderr, "Environment mismatch for %s:\nexpected: %s\nactual: %s\n",
+			name, expected, actual == NULL ? "(unset)" : actual);
+		exit(2);
+	}
+}
 
 int main(int argc, char **argv)
 {
@@ -31,13 +82,24 @@ int main(int argc, char **argv)
 	GSM_Error error;
 	GSM_MultiSMSMessage sms;
 	GSM_SMSDConfig *smsd;
+	const char *mode = "PDU";
+	int first_expectation = 2;
+	int i;
 #if 0
 	GSM_SMS_Backup bkp;
 #endif
 
 	/* Check parameters */
-	if (argc != 2 && argc != 3) {
-		printf("Not enough parameters!\nUsage: sms-at-parse comm.dump [PDU|TXT|TXTDETAIL]\n");
+	if (argc >= 3 &&
+	    (strcmp(argv[2], "PDU") == 0 ||
+	     strcmp(argv[2], "TXT") == 0 ||
+	     strcmp(argv[2], "TXTDETAIL") == 0)) {
+		mode = argv[2];
+		first_expectation = 3;
+	}
+	if (argc < 2) {
+		printf("Not enough parameters!\n");
+		printf("Usage: sms-at-parse comm.dump [PDU|TXT|TXTDETAIL] [NAME=VALUE]...\n");
 		return 1;
 	}
 
@@ -81,10 +143,10 @@ int main(int argc, char **argv)
 	Priv = &s->Phone.Data.Priv.ATGEN;
 	Priv->ReplyState = AT_Reply_OK;
 	Priv->Charset = AT_CHARSET_GSM;
-	if (argc == 3 && strcmp(argv[2], "TXT") == 0) {
+	if (strcmp(mode, "TXT") == 0) {
 		Priv->SMSMode = SMS_AT_TXT;
 		Priv->SMSTextDetails = FALSE;
-	} else if (argc == 3 && strcmp(argv[2], "TXTDETAIL") == 0) {
+	} else if (strcmp(mode, "TXTDETAIL") == 0) {
 		Priv->SMSMode = SMS_AT_TXT;
 		Priv->SMSTextDetails = TRUE;
 	} else {
@@ -118,6 +180,9 @@ int main(int argc, char **argv)
 		printf("Parts: %d, count: %d, ID16: %d, ID8: %d\n", sms.SMS[0].UDH.AllParts, sms.Number, sms.SMS[0].UDH.ID16bit, sms.SMS[0].UDH.ID8bit);
 
 		SMSD_RunOnEnvironment(&sms, smsd, NULL, TRUE);
+		for (i = first_expectation; i < argc; i++) {
+			check_environment(argv[i]);
+		}
 	}
 
 	/* This is normally done by ATGEN_Terminate */


### PR DESCRIPTION
The existing issue #300 fixture exercised MMS parsing but did not assert the exported metadata, allowing incomplete decoding to pass unnoticed. Check the decoded sender, title, address, size, and part counts.

Closes #300