### PR TITLE
fix(config): activate all configuration slots

### DIFF
--- a/libgammu/gsmstate.c
+++ b/libgammu/gsmstate.c
@@ -1441,7 +1441,7 @@ GSM_Config *GSM_GetConfig(GSM_StateMachine *s, int num)
 	if (num == -1) {
 		return s->CurrentConfig;
 	} else {
-		if (num > MAX_CONFIG_NUM) return NULL;
+		if (num >= MAX_CONFIG_NUM) return NULL;
 		return &(s->Config[num]);
 	}
 }
@@ -1902,7 +1902,7 @@ void GSM_FreeStateMachine(GSM_StateMachine *s)
 	if (s == NULL) return;
 
 	/* Free allocated memory */
-	for (i = 0; i <= MAX_CONFIG_NUM; i++) {
+	for (i = 0; i < MAX_CONFIG_NUM; i++) {
 		free(s->Config[i].Device);
 		s->Config[i].Device = NULL;
 		free(s->Config[i].Connection);

--- a/libgammu/gsmstate.h
+++ b/libgammu/gsmstate.h
@@ -1464,7 +1464,7 @@ struct _GSM_User {
 /**
  * Maximum number of concurrent configurations.
  */
-#define MAX_CONFIG_NUM		5
+#define MAX_CONFIG_NUM		6
 
 struct _GSM_StateMachine {
 	GSM_ConnectionType 	ConnectionType;				/**< Type of connection as int			*/
@@ -1479,7 +1479,7 @@ struct _GSM_StateMachine {
 	char			*LockFile;				/**< Lock file name for Unix 			*/
 	GSM_Debug_Info		di;					/**< Debug information				*/
 	gboolean			opened;					/**< Is connection opened ?			*/
-	GSM_Config		Config[MAX_CONFIG_NUM + 1];		/**< Configuration data */
+	GSM_Config		Config[MAX_CONFIG_NUM];			/**< Configuration data */
 	GSM_Config		*CurrentConfig;				/**< Config file (or Registry or...) variables 	*/
 	int			ConfigNum;				/**< Number of actual configurations */
 	int			ReplyNum;				/**< How many times make sth. 			*/

--- a/tests/statemachine-init.c
+++ b/tests/statemachine-init.c
@@ -13,6 +13,20 @@
 
 GSM_StateMachine *s;
 
+void config_count_check(void)
+{
+	s = GSM_AllocStateMachine();
+	test_result(s != NULL);
+
+	test_result(GSM_GetConfig(s, 5) != NULL);
+	test_result(GSM_GetConfig(s, 6) == NULL);
+
+	GSM_SetConfigNum(s, 6);
+	test_result(GSM_GetConfigNum(s) == 6);
+
+	GSM_FreeStateMachine(s);
+}
+
 void single_check(const char *device, const char *connection, const char *model, GSM_Error expected)
 {
 	GSM_Config *smcfg;
@@ -50,6 +64,7 @@ int main(int argc UNUSED, char **argv UNUSED)
 	GSM_SetDebugFileDescriptor(stderr, FALSE, debug_info);
 	GSM_SetDebugLevel("textall", debug_info);
 
+	config_count_check();
 	single_check("/NONEXISTING/DEVICE/NODE", "NONSENSE", "", ERR_UNKNOWNCONNECTIONTYPESTRING);
 #ifdef GSM_ENABLE_AT
 	single_check("/NONEXISTING/DEVICE/NODE", "at", "", ERR_DEVICENOTEXIST);


### PR DESCRIPTION
The state machine allocated six slots but only allowed five active configurations, so [gammu5] was ignored during initialization.

Closes #414