### PR TITLE
fix(build): eliminate cross-platform compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@
 
 cmake_minimum_required (VERSION 3.10)
 
+# Let modern linkers discard duplicate static libraries from transitive
+# dependencies.  Among other things, this avoids duplicate-library warnings
+# from recent Apple linkers.
+if (POLICY CMP0156)
+    cmake_policy (SET CMP0156 NEW)
+endif ()
+
 project (Gammu C)
 
 # Where to lookup modules
@@ -417,6 +424,11 @@ endif (POSTGRES_FOUND)
 if(MSVC)
     # MSVC needs different flags at all
     MACRO_TUNE_COMPILER("/W3")
+    # GCC and Clang do not include implicit conversion diagnostics in the
+    # warning levels used below.  Keep the MSVC warning set consistent rather
+    # than producing hundreds of warnings for bounded protocol values.
+    MACRO_TUNE_COMPILER("/wd4244")
+    MACRO_TUNE_COMPILER("/wd4267")
     # we use old runtime
     add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
     # we use strcpy instead of strcpy_s
@@ -448,6 +460,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_MINGW OR
     # Warnings related flags
     #
     MACRO_TUNE_COMPILER("-O2")
+    # Tentative definitions should live in BSS, not oversized common sections.
+    MACRO_TUNE_COMPILER("-fno-common")
     MACRO_TUNE_COMPILER("-Wall")
     MACRO_TUNE_COMPILER("-Werror-implicit-function-declaration")
     MACRO_TUNE_COMPILER("-Wno-deprecated-declarations")

--- a/contrib/smscgi/sms_cgi.c
+++ b/contrib/smscgi/sms_cgi.c
@@ -339,7 +339,7 @@ static void cgi_signal_handler(int signum) {
 	}
 }
 
-void cgi_reset() {
+void cgi_reset(void) {
 	int i = 0;
 	for(i = 0; i<GSM_MAX_MULTI_SMS ; i++) {
 		smsQ.SMS[i].Location = -1;

--- a/libgammu/gsmcomon.c
+++ b/libgammu/gsmcomon.c
@@ -215,7 +215,7 @@ const char *GetGammuVersion(void)
 	return Buffer;
 }
 
-GSM_Debug_Info *GSM_GetGlobalDebug()
+GSM_Debug_Info *GSM_GetGlobalDebug(void)
 {
 	return &GSM_global_debug;
 }

--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -1388,7 +1388,7 @@ void GetBufferI(unsigned char 	*Source,
 {
 	size_t l=0,z,i=0;
 
-	z = 1 << (BitsToProcess - 1);
+	z = (size_t)1 << (BitsToProcess - 1);
 
 	while (i!=BitsToProcess) {
 		if (GetBit(Source, (*CurrentBit)+i)) l=l+z;

--- a/libgammu/misc/misc.c
+++ b/libgammu/misc/misc.c
@@ -168,7 +168,7 @@ int get_local_timezone_offset(time_t posix_time)
   return posix_time - mktime(tm);
 }
 
-int GSM_GetLocalTimezoneOffset()
+int GSM_GetLocalTimezoneOffset(void)
 {
   return get_local_timezone_offset(time(NULL));
 }
@@ -575,8 +575,11 @@ void CopyLineString(char *dest, const char *src, const GSM_CutLines *lines, int 
 const char *GetOS(void)
 {
 #ifdef WIN32
-	OSVERSIONINFOEX Ver;
-	gboolean		Extended = TRUE;
+	typedef LONG (WINAPI *RtlGetVersionFunction)(OSVERSIONINFOW *);
+	OSVERSIONINFOEXW Ver;
+	HMODULE ntdll;
+	FARPROC procedure;
+	RtlGetVersionFunction get_version;
 #else
 #  ifdef HAVE_SYS_UTSNAME_H
 	struct utsname	Ver;
@@ -588,16 +591,17 @@ const char *GetOS(void)
 	if (Buffer[0] != 0) return Buffer;
 
 #ifdef WIN32
-	memset(&Ver,0,sizeof(OSVERSIONINFOEX));
-	Ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-
-   	if (!GetVersionEx((OSVERSIONINFO *)&Ver)) {
-		Extended 		= FALSE;
-	      	Ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	        if (!GetVersionEx((OSVERSIONINFO *)&Ver)) {
-			snprintf(Buffer, sizeof(Buffer) - 1, "Windows");
-			return Buffer;
-		}
+	memset(&Ver, 0, sizeof(Ver));
+	Ver.dwOSVersionInfoSize = sizeof(Ver);
+	ntdll = GetModuleHandleA("ntdll.dll");
+	procedure = ntdll == NULL
+		? NULL
+		: GetProcAddress(ntdll, "RtlGetVersion");
+	memcpy(&get_version, &procedure, sizeof(get_version));
+	if (get_version == NULL ||
+	    get_version((OSVERSIONINFOW *)&Ver) != 0) {
+		snprintf(Buffer, sizeof(Buffer) - 1, "Windows");
+		return Buffer;
 	}
 
 	/* ----------------- 9x family ------------------ */
@@ -628,12 +632,10 @@ const char *GetOS(void)
 	} else if (Ver.dwMajorVersion == 5 && Ver.dwMinorVersion == 1 && Ver.dwBuildNumber == 2600) {
 		snprintf(Buffer, sizeof(Buffer) - 1, "Windows XP");
 #if _MSC_VER > 1200 /* 6.0 has it undeclared */
-		if (Extended) {
-			if (Ver.wSuiteMask & VER_SUITE_PERSONAL) {
-				snprintf(Buffer+strlen(Buffer), sizeof(Buffer) - 1 - strlen(Buffer)," Home");
-			} else {
-				snprintf(Buffer+strlen(Buffer), sizeof(Buffer) - 1 - strlen(Buffer)," Pro");
-			}
+		if (Ver.wSuiteMask & VER_SUITE_PERSONAL) {
+			snprintf(Buffer+strlen(Buffer), sizeof(Buffer) - 1 - strlen(Buffer)," Home");
+		} else {
+			snprintf(Buffer+strlen(Buffer), sizeof(Buffer) - 1 - strlen(Buffer)," Pro");
 		}
 #endif
 
@@ -650,7 +652,7 @@ const char *GetOS(void)
 		snprintf(Buffer, sizeof(Buffer) - 1, "Windows %i.%i.%i",(int)Ver.dwMajorVersion,(int)Ver.dwMinorVersion,(int)Ver.dwBuildNumber);
 	}
 
-	if (Extended && Ver.wServicePackMajor != 0) {
+	if (Ver.wServicePackMajor != 0) {
 		snprintf(Buffer+strlen(Buffer), sizeof(Buffer) - 1 - strlen(Buffer)," SP%i",Ver.wServicePackMajor);
 	}
 #elif defined(HAVE_SYS_UTSNAME_H)

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -1486,7 +1486,7 @@ GSM_Error ATGEN_DispatchMessage(GSM_StateMachine *s)
 	GSM_Phone_ATGENData 	*Priv 	= &s->Phone.Data.Priv.ATGEN;
 	GSM_Protocol_Message	*msg	= s->Phone.Data.RequestMsg;
 	int 			i = 0,j = 0,k = 0;
-	const char		*err, *line;
+	const char		*err, *line = "";
 	ATErrorCode		*ErrorCodes = NULL;
 	char *line1, *line2;
 

--- a/libgammu/phone/at/sonyericsson.c
+++ b/libgammu/phone/at/sonyericsson.c
@@ -205,7 +205,7 @@ static int SONYERICSSON_Screenshot_createBMPHeader(unsigned int w, unsigned int 
 	u32_store(p+18, data);
 
 	// height in pixels (-320)
-	data = (u32)(-h);
+	data = 0U - h;
 	u32_store(p+22, data);
 
 	// color planes (1)

--- a/libgammu/phone/nokia/dct4s40/6510/n6510.c
+++ b/libgammu/phone/nokia/dct4s40/6510/n6510.c
@@ -3494,11 +3494,11 @@ static GSM_Error N6510_ReplySetProfile(GSM_Protocol_Message *msg, GSM_StateMachi
 
 static GSM_Error N6510_SetProfile(GSM_StateMachine *s, GSM_Profile *Profile)
 {
-	int 		i, length = 7, blocks = 0;
+	int 		i, length = 7;
 	gboolean		found;
-	unsigned char	ID,Value;
+	unsigned char	ID,Value,blocks = 0;
 	unsigned char 	req[150] = {N6110_FRAME_HEADER, 0x03, 0x01,
-				    0x06,		/* Number of blocks */
+				    0x00,		/* Number of blocks, filled below */
 				    0x03};
 
 	if (!GSM_IsPhoneFeatureAvailable(s->Phone.Data.ModelInfo, F_PROFILES)) return ERR_NOTSUPPORTED;
@@ -3531,6 +3531,7 @@ static GSM_Error N6510_SetProfile(GSM_StateMachine *s, GSM_Profile *Profile)
 			length += 9;
 		}
 	}
+	req[5] = blocks;
 
 	smprintf(s, "Setting profile\n");
 	return GSM_WaitFor (s, req, length, 0x39, s->Phone.Data.Priv.N6510.Timeout, ID_SetProfile);

--- a/libgammu/service/backup/backtext.c
+++ b/libgammu/service/backup/backtext.c
@@ -1073,9 +1073,18 @@ static GSM_Error SaveSyncMLSettingsEntry(FILE *file, GSM_SyncMLSettings *setting
 
 static GSM_Error SaveBitmapEntry(FILE *file, GSM_Bitmap *bitmap, gboolean UseUnicode)
 {
-	unsigned char 	buffer[10000]={0},buffer2[10000]={0};
+	char buffer[GSM_BITMAP_SIZE * 8 + 1] = {0};
+	char buffer2[sizeof(buffer) + 32] = {0};
 	size_t		x,y;
+	int written;
 	GSM_Error error;
+
+	if (bitmap->BitmapWidth > GSM_BITMAP_SIZE * 8 ||
+	    bitmap->BitmapHeight > GSM_BITMAP_SIZE * 8 ||
+	    (bitmap->BitmapWidth != 0 &&
+	     bitmap->BitmapHeight > GSM_BITMAP_SIZE * 8 / bitmap->BitmapWidth)) {
+		return ERR_INVALIDDATA;
+	}
 
 	sprintf(buffer,"Width = %ld%c%c", (long)bitmap->BitmapWidth,13,10);
 	error = SaveBackupText(file, "", buffer, UseUnicode);
@@ -1086,10 +1095,15 @@ static GSM_Error SaveBitmapEntry(FILE *file, GSM_Bitmap *bitmap, gboolean UseUni
 	for (y=0;y<bitmap->BitmapHeight;y++) {
 		for (x=0;x<bitmap->BitmapWidth;x++) {
 			buffer[x] = ' ';
-			if (GSM_IsPointBitmap(bitmap,x,y)) buffer[x]='#';
+			if (GSM_IsPointBitmap(bitmap,(int)x,(int)y)) buffer[x]='#';
 		}
 		buffer[bitmap->BitmapWidth] = 0;
-		sprintf(buffer2,"Bitmap%02i = \"%s\"%c%c",(int)y,buffer,13,10);
+		written = snprintf(buffer2, sizeof(buffer2),
+				   "Bitmap%02i = \"%s\"%c%c",
+				   (int)y, buffer, 13, 10);
+		if (written < 0 || (size_t)written >= sizeof(buffer2)) {
+			return ERR_INVALIDDATA;
+		}
 		error = SaveBackupText(file, "", buffer2, UseUnicode);
 		if (error != ERR_NONE) return error;
 	}

--- a/smsd/core.c
+++ b/smsd/core.c
@@ -1156,7 +1156,7 @@ static void SMSD_RunOnDateTimeEnvironment(int index, const char *prefix, GSM_Dat
 	char datetime_buffer[100], name[100], timestamp_buffer[100];
 	char timezone_sign;
 	int written;
-	long long timezone;
+	long long timezone_offset;
 	time_t timestamp;
 
 	snprintf(name, sizeof(name), "SMS_%d_%sTIMESTAMP", index, prefix);
@@ -1176,10 +1176,10 @@ static void SMSD_RunOnDateTimeEnvironment(int index, const char *prefix, GSM_Dat
 		setenv(name, timestamp_buffer, 1);
 	}
 
-	timezone = datetime.Timezone;
-	if (timezone < 0) {
+	timezone_offset = datetime.Timezone;
+	if (timezone_offset < 0) {
 		timezone_sign = '-';
-		timezone = -timezone;
+		timezone_offset = -timezone_offset;
 	} else {
 		timezone_sign = '+';
 	}
@@ -1187,7 +1187,8 @@ static void SMSD_RunOnDateTimeEnvironment(int index, const char *prefix, GSM_Dat
 		"%04d-%02d-%02dT%02d:%02d:%02d%c%02lld:%02lld",
 		datetime.Year, datetime.Month, datetime.Day,
 		datetime.Hour, datetime.Minute, datetime.Second,
-		timezone_sign, timezone / 3600, (timezone % 3600) / 60);
+		timezone_sign, timezone_offset / 3600,
+		(timezone_offset % 3600) / 60);
 	if (written < 0 || (size_t)written >= sizeof(datetime_buffer)) {
 		return;
 	}

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -16,7 +16,7 @@
 #endif
 
 #define SMSD_SHM_VERSION (2)
-#define SMSD_SHM_KEY (0xfa << 16 || SMSD_SHM_VERSION)
+#define SMSD_SHM_KEY (0xfa << 16 | SMSD_SHM_VERSION)
 #define SMSD_DB_VERSION (17)
 
 #include "log.h"


### PR DESCRIPTION
Fix portability and bounds issues exposed by GCC, Clang, and MSVC while aligning equivalent warning policies and modern linker behavior.