### PR TITLE
refactor(smsd): use SHM version as ftok project ID

### DIFF
--- a/smsd/core.c
+++ b/smsd/core.c
@@ -749,7 +749,7 @@ GSM_Error SMSD_ReadConfig(const char *filename, GSM_SMSDConfig *Config, gboolean
 		strncpy(fullpath, filename, PATH_MAX);
 		fullpath[PATH_MAX] = 0;
 	}
-	Config->shm_key = ftok(fullpath, SMSD_SHM_KEY);
+	Config->shm_key = ftok(fullpath, SMSD_SHM_VERSION);
 	if (Config->shm_key < 0) {
 		fprintf(stderr, "Failed to generate SHM key!\n");
 		return FALSE;

--- a/smsd/core.h
+++ b/smsd/core.h
@@ -16,7 +16,6 @@
 #endif
 
 #define SMSD_SHM_VERSION (2)
-#define SMSD_SHM_KEY (0xfa << 16 | SMSD_SHM_VERSION)
 #define SMSD_DB_VERSION (17)
 
 #include "log.h"


### PR DESCRIPTION
ftok only consumes the low eight bits of its project ID, so remove the misleading composite key and pass the shared-memory version directly.