### PR TITLE
fix(unicode): prevent truncation on invalid locale input

### DIFF
--- a/docs/man/gammu-smsd-inject.1
+++ b/docs/man/gammu-smsd-inject.1
@@ -111,10 +111,13 @@ Inject unicode text message:
 .INDENT 3.5
 .sp
 .EX
-gammu\-smsd\-inject TEXT 123456 \-unicode \-text \(dqZkouška sirén\(dq
+gammu\-smsd\-inject TEXT 123456 \-unicode \-textutf8 \(dqZkouška sirén\(dq
 .EE
 .UNINDENT
 .UNINDENT
+.sp
+Use \fB\-textutf8\fP for UTF\-8 text supplied by applications or services, where
+the locale inherited by \fBgammu\-smsd\-inject\fP might not be configured.
 .sp
 Inject long text message:
 .INDENT 0.0

--- a/docs/man/gammu.1
+++ b/docs/man/gammu.1
@@ -480,12 +480,17 @@ Added in version 1.38.5.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B EMS [\-unicode] [\-16bit] [\-format lcrasbiut] [\-text text] [\-unicodefiletext file] [\-defsound ID] [\-defanimation ID] [\-tone10 file] [\-tone10long file] [\-tone12 file] [\-tone12long file] [\-toneSE file] [\-toneSElong file] [\-fixedbitmap file] [\-variablebitmap file] [\-variablebitmaplong file] [\-animation frames file1 ...] [\-protected number]
+.B EMS [\-unicode] [\-16bit] [\-format lcrasbiut] [\-text text] [\-textutf8 text] [\-unicodefiletext file] [\-defsound ID] [\-defanimation ID] [\-tone10 file] [\-tone10long file] [\-tone12 file] [\-tone12long file] [\-toneSE file] [\-toneSElong file] [\-fixedbitmap file] [\-variablebitmap file] [\-variablebitmaplong file] [\-animation frames file1 ...] [\-protected number]
 Saves EMS sequence. All format specific parameters (like \fB\-defsound\fP) can be used few times.
 .INDENT 7.0
 .TP
 .B \-text
 adds text
+.UNINDENT
+.INDENT 7.0
+.TP
+.B \-textutf8
+adds UTF\-8 text
 .UNINDENT
 .INDENT 7.0
 .TP
@@ -676,7 +681,7 @@ filesystem commands.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B PICTURE file  [\-text text] [\-unicode] [\-alcatelbmmi]
+.B PICTURE file  [\-text text] [\-textutf8 text] [\-unicode] [\-alcatelbmmi]
 Read bitmap from 2 colors file (bmp, nlm, nsl, ngg, nol, wbmp, etc.), format
 into bitmap in Smart Messaging (72x28, 2 colors, called often Picture Image
 and saved with text) or Alcatel format and send/save over SMS.
@@ -715,7 +720,7 @@ it correctly later in phone composer (for example, in 33xx)
 .UNINDENT
 .INDENT 0.0
 .TP
-.B SMSTEMPLATE  [\-unicode] [\-text text] [\-unicodefiletext file] [\-defsound ID] [\-defanimation ID] [\-tone10 file] [\-tone10long file] [\-tone12 file] [\-tone12long file] [\-toneSE file] [\-toneSElong file] [\-variablebitmap file] [\-variablebitmaplong file] [\-animation frames file1 ...]
+.B SMSTEMPLATE  [\-unicode] [\-text text] [\-textutf8 text] [\-unicodefiletext file] [\-defsound ID] [\-defanimation ID] [\-tone10 file] [\-tone10long file] [\-tone12 file] [\-tone12long file] [\-toneSE file] [\-toneSElong file] [\-variablebitmap file] [\-variablebitmaplong file] [\-animation frames file1 ...]
 Saves a SMS template (for Alcatel phones).
 .UNINDENT
 .INDENT 0.0

--- a/docs/manual/c/unicode.rst
+++ b/docs/manual/c/unicode.rst
@@ -5,7 +5,9 @@ Unicode
 .. doxygenfunction:: DecodeUnicodeString
 .. doxygenfunction:: DecodeUnicodeConsole
 .. doxygenfunction:: DecodeUnicode
+.. doxygenfunction:: DecodeUTF8Checked
 .. doxygenfunction:: EncodeUnicode
+.. doxygenfunction:: EncodeUnicodeChecked
 .. doxygenfunction:: ReadUnicodeFile
 .. doxygenfunction:: CopyUnicodeString
 .. doxygenfunction:: EncodeUTF8QuotedPrintable

--- a/docs/manual/gammu/index.rst
+++ b/docs/manual/gammu/index.rst
@@ -396,13 +396,17 @@ ____________
 
         .. versionadded:: 1.38.5
 
-    .. option:: EMS [-unicode] [-16bit] [-format lcrasbiut] [-text text] [-unicodefiletext file] [-defsound ID] [-defanimation ID] [-tone10 file] [-tone10long file] [-tone12 file] [-tone12long file] [-toneSE file] [-toneSElong file] [-fixedbitmap file] [-variablebitmap file] [-variablebitmaplong file] [-animation frames file1 ...] [-protected number]
+    .. option:: EMS [-unicode] [-16bit] [-format lcrasbiut] [-text text] [-textutf8 text] [-unicodefiletext file] [-defsound ID] [-defanimation ID] [-tone10 file] [-tone10long file] [-tone12 file] [-tone12long file] [-toneSE file] [-toneSElong file] [-fixedbitmap file] [-variablebitmap file] [-variablebitmaplong file] [-animation frames file1 ...] [-protected number]
 
         Saves EMS sequence. All format specific parameters (like :option:`-defsound`) can be used few times.
 
         .. option:: -text
 
             adds text
+
+        .. option:: -textutf8
+
+            adds UTF-8 text
 
         .. option:: -unicodefiletext
 
@@ -520,7 +524,7 @@ ____________
            filesystem commands.
 
 
-    .. option:: PICTURE file  [-text text] [-unicode] [-alcatelbmmi]
+    .. option:: PICTURE file  [-text text] [-textutf8 text] [-unicode] [-alcatelbmmi]
 
         Read bitmap from 2 colors file (bmp, nlm, nsl, ngg, nol, wbmp, etc.), format
         into bitmap in Smart Messaging (72x28, 2 colors, called often Picture Image
@@ -554,7 +558,7 @@ ____________
             it correctly later in phone composer (for example, in 33xx)
 
 
-    .. option:: SMSTEMPLATE  [-unicode] [-text text] [-unicodefiletext file] [-defsound ID] [-defanimation ID] [-tone10 file] [-tone10long file] [-tone12 file] [-tone12long file] [-toneSE file] [-toneSElong file] [-variablebitmap file] [-variablebitmaplong file] [-animation frames file1 ...]
+    .. option:: SMSTEMPLATE  [-unicode] [-text text] [-textutf8 text] [-unicodefiletext file] [-defsound ID] [-defanimation ID] [-tone10 file] [-tone10long file] [-tone12 file] [-tone12long file] [-toneSE file] [-toneSElong file] [-variablebitmap file] [-variablebitmaplong file] [-animation frames file1 ...]
 
         Saves a SMS template (for Alcatel phones).
 

--- a/docs/manual/smsd/inject.rst
+++ b/docs/manual/smsd/inject.rst
@@ -74,7 +74,10 @@ Inject unicode text message:
 
 .. code-block:: sh
 
-    gammu-smsd-inject TEXT 123456 -unicode -text "Zkouška sirén"
+    gammu-smsd-inject TEXT 123456 -unicode -textutf8 "Zkouška sirén"
+
+Use ``-textutf8`` for UTF-8 text supplied by applications or services, where
+the locale inherited by :program:`gammu-smsd-inject` might not be configured.
 
 Inject long text message:
 

--- a/gammu/CMakeTests.txt
+++ b/gammu/CMakeTests.txt
@@ -27,6 +27,11 @@ set_tests_properties(gammu-help-all PROPERTIES
     PASS_REGULAR_EXPRESSION "batch"
     )
 
+add_test(gammu-help-sms "${CMAKE_CURRENT_BINARY_DIR}/gammu${CMAKE_EXECUTABLE_SUFFIX}" help sms)
+set_tests_properties(gammu-help-sms PROPERTIES
+    PASS_REGULAR_EXPRESSION "\\[-text text\\]\\[-textutf8 text\\]\\[-unicode\\]"
+    )
+
 add_test(gammu-nets "${CMAKE_CURRENT_BINARY_DIR}/gammu${CMAKE_EXECUTABLE_SUFFIX}" listnetworks)
 set_tests_properties(gammu-nets PROPERTIES
     PASS_REGULAR_EXPRESSION "901 29     Telenor"

--- a/gammu/gammu.c
+++ b/gammu/gammu.c
@@ -555,10 +555,10 @@ static GSM_Parameters Parameters[] = {
 	{"geteachsms",		0, 1, GetEachSMS,		{H_SMS,0},			"-pbk"},
 
 #define SMS_TEXT_OPTIONS	"[-inputunicode][-16bit][-flash][-len len][-autolen len][-unicode][-enablevoice][-disablevoice][-enablefax][-disablefax][-enableemail][-disableemail][-voidsms][-replacemessages ID][-replacefile file][-text msgtext][-textutf8 msgtext]"
-#define SMS_PICTURE_OPTIONS	"[-text text][-unicode][-alcatelbmmi]"
+#define SMS_PICTURE_OPTIONS	"[-text text][-textutf8 text][-unicode][-alcatelbmmi]"
 #define SMS_PROFILE_OPTIONS	"[-name name][-bitmap bitmap][-ringtone ringtone]"
-#define SMS_EMS_OPTIONS		"[-unicode][-16bit][-format lcrasbiut][-text text][-unicodefiletext file][-defsound ID][-defanimation ID][-tone10 file][-tone10long file][-tone12 file][-tone12long file][-toneSE file][-toneSElong file][-fixedbitmap file][-variablebitmap file][-variablebitmaplong file][-animation frames file1 ...][-protected number]"
-#define SMS_SMSTEMPLATE_OPTIONS	"[-unicode][-text text][-unicodefiletext file][-defsound ID][-defanimation ID][-tone10 file][-tone10long file][-tone12 file][-tone12long file][-toneSE file][-toneSElong file][-variablebitmap file][-variablebitmaplong file][-animation frames file1 ...]"
+#define SMS_EMS_OPTIONS		"[-unicode][-16bit][-format lcrasbiut][-text text][-textutf8 text][-unicodefiletext file][-defsound ID][-defanimation ID][-tone10 file][-tone10long file][-tone12 file][-tone12long file][-toneSE file][-toneSElong file][-fixedbitmap file][-variablebitmap file][-variablebitmaplong file][-animation frames file1 ...][-protected number]"
+#define SMS_SMSTEMPLATE_OPTIONS	"[-unicode][-text text][-textutf8 text][-unicodefiletext file][-defsound ID][-defanimation ID][-tone10 file][-tone10long file][-tone12 file][-tone12long file][-toneSE file][-toneSElong file][-variablebitmap file][-variablebitmaplong file][-animation frames file1 ...]"
 #define SMS_ANIMATION_OPTIONS	""
 #define SMS_OPERATOR_OPTIONS	"[-netcode netcode][-biglogo]"
 #define SMS_RINGTONE_OPTIONS	"[-long][-scale]"

--- a/helper/message-cmdline.c
+++ b/helper/message-cmdline.c
@@ -94,6 +94,28 @@ ComposeMapEntry ComposeMap[] = {
 
 #define SEND_SAVE_SMS_BUFFER_SIZE 10000
 
+static GSM_Error EncodeMessageText(unsigned char *dest, const char *src,
+				   size_t len, gboolean utf8)
+{
+	if (utf8) {
+		if (!DecodeUTF8Checked(dest, src, len)) {
+			printf_err("%s\n",
+				   _("Cannot decode message text: invalid UTF-8 "
+				     "input."));
+			return ERR_INVALIDDATA;
+		}
+		return ERR_NONE;
+	}
+	if (!EncodeUnicodeChecked(dest, src, len)) {
+		printf_err("%s\n",
+			   _("Cannot convert message text to Unicode: invalid "
+			     "character for current locale. Use -textutf8 for "
+			     "UTF-8 input."));
+		return ERR_INVALIDDATA;
+	}
+	return ERR_NONE;
+}
+
 GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int argc, int typearg, char *argv[], GSM_StateMachine *sm)
 {
 	/**
@@ -123,6 +145,7 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 	gboolean				ReplyViaSameSMSC 	= FALSE;
 	int				MaxSMS			= -1;
 	gboolean				EMS16Bit		= FALSE;
+	gboolean				TextUTF8		= FALSE;
 	int frames_num;
 	ssize_t param_value;
 
@@ -670,11 +693,13 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 			}
 			if (compose_type == COMPOSE_TEXT) {
 				if (strcasecmp(argv[i],"-text") == 0) {
+					TextUTF8 = FALSE;
 					nextlong = 26;
 					break;
 				}
 				if (strcasecmp(argv[i],"-textutf8") == 0) {
-					nextlong = 27;
+					TextUTF8 = TRUE;
+					nextlong = 26;
 					break;
 				}
 				if (strcasecmp(argv[i],"-inputunicode") == 0) {
@@ -747,6 +772,12 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 			}
 			if (compose_type == COMPOSE_PICTURE) {
 				if (strcasecmp(argv[i],"-text") == 0) {
+					TextUTF8 = FALSE;
+					nextlong = 6;
+					break;
+				}
+				if (strcasecmp(argv[i],"-textutf8") == 0) {
+					TextUTF8 = TRUE;
 					nextlong = 6;
 					break;
 				}
@@ -799,6 +830,12 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 					break;
 				}
 				if (strcasecmp(argv[i],"-text") == 0) {
+					TextUTF8 = FALSE;
+					nextlong = 11;
+					break;
+				}
+				if (strcasecmp(argv[i],"-textutf8") == 0) {
+					TextUTF8 = TRUE;
 					nextlong = 11;
 					break;
 				}
@@ -914,6 +951,12 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 					break;
 				}
 				if (strcasecmp(argv[i],"-text") == 0) {
+					TextUTF8 = FALSE;
+					nextlong = 11;
+					break;
+				}
+				if (strcasecmp(argv[i],"-textutf8") == 0) {
+					TextUTF8 = TRUE;
 					nextlong = 11;
 					break;
 				}
@@ -1074,7 +1117,10 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 			break;
 		case 6:	/* Picture Images - text */
 			BMP_AUTO_ALLOC(0);
-			EncodeUnicode(bitmap[0]->Bitmap[0].Text,argv[i],strlen(argv[i]));
+			error = EncodeMessageText(bitmap[0]->Bitmap[0].Text,
+						  argv[i], strlen(argv[i]),
+						  TextUTF8);
+			if (error != ERR_NONE) goto end_compose;
 			nextlong = 0;
 			break;
 		case 7:	/* Operator Logo - network code */
@@ -1145,7 +1191,10 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 			nextlong = 0;
 			break;
 		case 11:/* EMS text from parameter */
-			EncodeUnicode(Buffer[SMSInfo.EntriesNum],argv[i],strlen(argv[i]));
+			error = EncodeMessageText(Buffer[SMSInfo.EntriesNum],
+						  argv[i], strlen(argv[i]),
+						  TextUTF8);
+			if (error != ERR_NONE) goto end_compose;
 			SMSInfo.Entries[SMSInfo.EntriesNum].ID 		= SMS_ConcatenatedTextLong;
 			SMSInfo.Entries[SMSInfo.EntriesNum].Buffer 	= Buffer[SMSInfo.EntriesNum];
 			SMSInfo.EntriesNum++;
@@ -1302,13 +1351,9 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 			break;
 		case 26:/* text from parameter */
 			chars_read = strlen(argv[i]);
-			EncodeUnicode(Buffer[0], argv[i], chars_read);
-			HasText = TRUE;
-			nextlong = 0;
-			break;
-		case 27:/* utf-8 text from parameter */
-			chars_read = strlen(argv[i]);
-			DecodeUTF8(Buffer[0], argv[i], chars_read);
+			error = EncodeMessageText(Buffer[0], argv[i], chars_read,
+						  TextUTF8);
+			if (error != ERR_NONE) goto end_compose;
 			HasText = TRUE;
 			nextlong = 0;
 			break;
@@ -1355,7 +1400,9 @@ GSM_Error CreateMessage(GSM_Message_Type *type, GSM_MultiSMSMessage *sms, int ar
 				printf_warn("%s\n", _("No chars read, assuming it is okay!"));
 			}
 
-			EncodeUnicode(Buffer[0],InputBuffer,chars_read);
+			error = EncodeMessageText(Buffer[0], InputBuffer,
+						  chars_read, FALSE);
+			if (error != ERR_NONE) goto end_compose;
 		}
 
 		chars_read = UnicodeLength(Buffer[0]);

--- a/include/gammu-unicode.h
+++ b/include/gammu-unicode.h
@@ -63,6 +63,19 @@ void DecodeUnicode(const unsigned char *src, char *dest);
 void EncodeUnicode(unsigned char *dest, const char *src, size_t len);
 
 /**
+ * Encodes string from local charset to unicode and reports conversion errors.
+ *
+ * Invalid input bytes are encoded as Unicode replacement characters and
+ * conversion continues, ensuring that the output is not silently truncated.
+ *
+ * \return TRUE if the complete input was valid in the current locale, FALSE
+ * otherwise.
+ *
+ * \ingroup Unicode
+ */
+gboolean EncodeUnicodeChecked(unsigned char *dest, const char *src, size_t len);
+
+/**
  * Decodes unicode file data with byte order mark (BOM).
  *
  * \ingroup Unicode
@@ -146,6 +159,15 @@ gboolean EncodeUTF8(char *dest, const unsigned char *src);
  * \ingroup Unicode
  */
 void DecodeUTF8(unsigned char *dest, const char *src, size_t len);
+
+/**
+ * Decode text from UTF-8 and report malformed input.
+ *
+ * \return TRUE if the complete input was valid UTF-8, FALSE otherwise.
+ *
+ * \ingroup Unicode
+ */
+gboolean DecodeUTF8Checked(unsigned char *dest, const char *src, size_t len);
 
 /**
  * Decode hex encoded binary text.

--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -194,20 +194,43 @@ size_t UnicodeLength(const unsigned char *str)
 	return len;
 }
 
-/* Convert Unicode char saved in src to dest */
-int EncodeWithUnicodeAlphabet(const unsigned char *src, gammu_char_t *dest)
+static int EncodeWithUnicodeAlphabetChecked(const unsigned char *src,
+					    size_t len,
+					    gammu_char_t *dest,
+					    gboolean *valid)
 {
 	int retval;
 	wchar_t out = 0;
 
-	retval = mbtowc(&out, src, MB_CUR_MAX);
-	*dest = out;
+	retval = mbtowc(&out, (const char *)src,
+			len < MB_CUR_MAX ? len : MB_CUR_MAX);
 
 	switch (retval) {
-		case -1 :
-		case  0 : return 1;
-		default : return retval;
+		case -1:
+			/*
+			 * Do not insert a NUL on conversion errors as that
+			 * silently truncates the resulting Unicode string.
+			 */
+			*dest = 0xFFFD;
+			if (valid != NULL) {
+				*valid = FALSE;
+			}
+			/* Reset conversion state after an invalid sequence. */
+			mbtowc(NULL, NULL, 0);
+			return 1;
+		case 0:
+			*dest = out;
+			return 1;
+		default:
+			*dest = out;
+			return retval;
 	}
+}
+
+/* Convert Unicode char saved in src to dest */
+int EncodeWithUnicodeAlphabet(const unsigned char *src, gammu_char_t *dest)
+{
+	return EncodeWithUnicodeAlphabetChecked(src, MB_CUR_MAX, dest, NULL);
 }
 
 /* Convert Unicode char saved in src to dest */
@@ -333,19 +356,28 @@ size_t StoreUTF16 (unsigned char *dest, gammu_char_t wc)
 }
 
 /* Encode string to Unicode. Len is number of input chars */
-void EncodeUnicode (unsigned char *dest, const char *src, size_t len)
+gboolean EncodeUnicodeChecked(unsigned char *dest, const char *src, size_t len)
 {
 	size_t 		i_len = 0, o_len;
  	gammu_char_t 	wc;
+	gboolean	valid = TRUE;
 
 	for (o_len = 0; i_len < len; o_len++) {
-		i_len += EncodeWithUnicodeAlphabet(&src[i_len], &wc);
+		i_len += EncodeWithUnicodeAlphabetChecked(
+			(const unsigned char *)&src[i_len], len - i_len,
+			&wc, &valid);
 		if (StoreUTF16(dest + o_len * 2, wc)) {
 			o_len++;
 		}
  	}
 	dest[o_len*2]		= 0;
 	dest[(o_len*2)+1]	= 0;
+	return valid;
+}
+
+void EncodeUnicode (unsigned char *dest, const char *src, size_t len)
+{
+	EncodeUnicodeChecked(dest, src, len);
 }
 
 unsigned char EncodeWithBCDAlphabet(int value)
@@ -1930,6 +1962,9 @@ int DecodeWithUTF8Alphabet(const unsigned char *src, gammu_char_t *dest, size_t 
 		return 0;
 	}
 	src1 = src[1];
+	if ((src1 & 0xC0) != 0x80) {
+		return 0;
+	}
 
 	// 2-byte sequence
 	if ((src0 & 0xE0) == 0xC0) {
@@ -1945,6 +1980,9 @@ int DecodeWithUTF8Alphabet(const unsigned char *src, gammu_char_t *dest, size_t 
 		return 0;
 	}
 	src2 = src[2];
+	if ((src2 & 0xC0) != 0x80) {
+		return 0;
+	}
 
 	// 3-byte sequence (may include unpaired surrogates)
 	if ((src0 & 0xF0) == 0xE0) {
@@ -1961,6 +1999,9 @@ int DecodeWithUTF8Alphabet(const unsigned char *src, gammu_char_t *dest, size_t 
 		return 0;
 	}
 	src3 = src[3];
+	if ((src3 & 0xC0) != 0x80) {
+		return 0;
+	}
 
 	// 4-byte sequence
 	if ((src0 & 0xF8) == 0xF0) {
@@ -2037,7 +2078,7 @@ void DecodeUTF8QuotedPrintable(unsigned char *dest, const char *src, size_t len)
 	dest[j] = 0;
 }
 
-void DecodeUTF8(unsigned char *dest, const char *src, size_t len)
+gboolean DecodeUTF8Checked(unsigned char *dest, const char *src, size_t len)
 {
 	size_t 		i=0,j=0,z;
 	gammu_char_t		ret;
@@ -2045,7 +2086,9 @@ void DecodeUTF8(unsigned char *dest, const char *src, size_t len)
 	while (i < len) {
 		z = DecodeWithUTF8Alphabet(src+i, &ret, len - i);
 		if (z < 1) {
-			break;
+			dest[j++] = 0;
+			dest[j] = 0;
+			return FALSE;
 		}
 		i += z;
 		if (StoreUTF16(dest + j, ret)) {
@@ -2056,6 +2099,12 @@ void DecodeUTF8(unsigned char *dest, const char *src, size_t len)
 	}
 	dest[j++] = 0;
 	dest[j] = 0;
+	return TRUE;
+}
+
+void DecodeUTF8(unsigned char *dest, const char *src, size_t len)
+{
+	DecodeUTF8Checked(dest, src, len);
 }
 
 void DecodeXMLUTF8(unsigned char *dest, const char *src, size_t len)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -837,9 +837,23 @@ set_tests_properties(sms-cmdline-TEXT-smsc PROPERTIES
 PASS_REGULAR_EXPRESSION "Remote number        : \"213\"")
 
 add_test(sms-cmdline-TEXT-textutf8 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
-    TEXT 213 -unicode -textutf8 "Zkouška šíleně žlutého koně.")
+    TEXT 213 -unicode -textutf8 "valid")
 set_tests_properties(sms-cmdline-TEXT-textutf8 PROPERTIES
+    ENVIRONMENT "LC_ALL=C;GAMMU_TEST_UTF8=1"
     PASS_REGULAR_EXPRESSION "Coding               : Unicode \\(no compression\\)")
+
+add_test(sms-cmdline-TEXT-invalid-locale "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
+    TEXT 213 -text "invalid")
+set_tests_properties(sms-cmdline-TEXT-invalid-locale PROPERTIES
+    ENVIRONMENT "GAMMU_EXPECT_INVALIDDATA=locale"
+    SKIP_RETURN_CODE 77
+    PASS_REGULAR_EXPRESSION "invalid character for current locale")
+
+add_test(sms-cmdline-TEXT-invalid-utf8 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
+    TEXT 213 -textutf8 "invalid")
+set_tests_properties(sms-cmdline-TEXT-invalid-utf8 PROPERTIES
+    ENVIRONMENT "GAMMU_EXPECT_INVALIDDATA=utf8"
+    PASS_REGULAR_EXPRESSION "invalid UTF-8 input")
 
 
 add_test(sms-cmdline-TEXT-16 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
@@ -915,6 +929,12 @@ add_test(sms-cmdline-EMS-unicodefile "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXEC
 set_tests_properties(sms-cmdline-EMS-unicodefile PROPERTIES
     PASS_REGULAR_EXPRESSION "Coding               : Unicode \\(no compression\\)")
 
+add_test(sms-cmdline-EMS-textutf8 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
+    EMS 213 -unicode -textutf8 "valid")
+set_tests_properties(sms-cmdline-EMS-textutf8 PROPERTIES
+    ENVIRONMENT "LC_ALL=C;GAMMU_TEST_UTF8=1"
+    PASS_REGULAR_EXPRESSION "Coding               : Unicode \\(no compression\\)")
+
 add_test(sms-cmdline-RINGTONE "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
     RINGTONE 54654654 ${RINGTONE_TEST_FILE})
 set_tests_properties(sms-cmdline-RINGTONE PROPERTIES
@@ -953,9 +973,21 @@ add_test(sms-cmdline-SMSTEMPLATE "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTAB
 set_tests_properties(sms-cmdline-SMSTEMPLATE PROPERTIES
     PASS_REGULAR_EXPRESSION "User Data Header     : User UDH")
 
+add_test(sms-cmdline-SMSTEMPLATE-textutf8 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
+    SMSTEMPLATE 213 -unicode -textutf8 "valid")
+set_tests_properties(sms-cmdline-SMSTEMPLATE-textutf8 PROPERTIES
+    ENVIRONMENT "LC_ALL=C;GAMMU_TEST_UTF8=1"
+    PASS_REGULAR_EXPRESSION "User Data Header     : User UDH")
+
 add_test(sms-cmdline-PICTURE "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
     PICTURE 213 ${LOGO_TEST_FILE})
 set_tests_properties(sms-cmdline-PICTURE PROPERTIES
+    PASS_REGULAR_EXPRESSION "###################   ##    ##     #     #     ##   ## ### ##   ###   ##")
+
+add_test(sms-cmdline-PICTURE-textutf8 "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"
+    PICTURE 213 ${LOGO_TEST_FILE} -unicode -textutf8 "valid")
+set_tests_properties(sms-cmdline-PICTURE-textutf8 PROPERTIES
+    ENVIRONMENT "LC_ALL=C;GAMMU_TEST_UTF8=1"
     PASS_REGULAR_EXPRESSION "###################   ##    ##     #     #     ##   ## ### ##   ###   ##")
 
 add_test(sms-cmdline-OPERATOR "${GAMMU_TEST_PATH}/sms-cmdline${CMAKE_EXECUTABLE_SUFFIX}"

--- a/tests/sms-cmdline.c
+++ b/tests/sms-cmdline.c
@@ -1,18 +1,92 @@
 #include <gammu.h>
+#include <locale.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "common.h"
 
 #include "../helper/message-display.h"
 #include "../helper/message-cmdline.h"
 
+#define SKIP_TEST 77
+
+static gboolean SetUTF8Locale(void)
+{
+	static const char *locales[] = {
+		"",
+		"C.UTF-8",
+		"C.utf8",
+		"en_US.UTF-8",
+		".UTF-8",
+	};
+	size_t i;
+	wchar_t decoded;
+
+	for (i = 0; i < sizeof(locales) / sizeof(locales[0]); i++) {
+		if (setlocale(LC_CTYPE, locales[i]) == NULL ||
+		    MB_CUR_MAX < 2) {
+			continue;
+		}
+		mbtowc(NULL, NULL, 0);
+		if (mbtowc(&decoded, "\xc3\xa9", 2) == 2 &&
+		    decoded == 0xe9) {
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}
+
 int main(int argc, char **argv)
 {
+	static char valid_utf8[] = {
+		'm', (char)0xc3, (char)0xa9, 't',
+		(char)0xc3, (char)0xa9, 'o', 0
+	};
+	static char invalid_locale[] = {
+		'a', (char)0xc3, 'z', 0
+	};
+	static char invalid_utf8[] = {
+		'o', 'k', (char)0xff, 'r', 'e', 's', 't', 0
+	};
 	GSM_MultiSMSMessage sms;
 	GSM_Error error;
 	GSM_Message_Type type = SMS_Display;
 	GSM_Debug_Info *debug_info;
+	const char *invalid_input;
 	int i;
+
+	GSM_InitLocales(NULL);
+
+	if (getenv("GAMMU_TEST_UTF8") != NULL) {
+		if (argc < 2) {
+			fprintf(stderr, "Missing message text argument\n");
+			return 2;
+		}
+		argv[argc - 1] = valid_utf8;
+	}
+
+	invalid_input = getenv("GAMMU_EXPECT_INVALIDDATA");
+	if (invalid_input != NULL) {
+		if (argc < 2) {
+			fprintf(stderr, "Missing message text argument\n");
+			return 2;
+		}
+		if (strcmp(invalid_input, "locale") == 0) {
+			if (!SetUTF8Locale()) {
+				fprintf(stderr,
+					"Skipping test: no UTF-8 locale available\n");
+				return SKIP_TEST;
+			}
+			argv[argc - 1] = invalid_locale;
+		} else if (strcmp(invalid_input, "utf8") == 0) {
+			argv[argc - 1] = invalid_utf8;
+		} else {
+			fprintf(stderr, "Unknown invalid input type: %s\n",
+				invalid_input);
+			return 2;
+		}
+	}
 
 	/* Configure debugging */
 	debug_info = GSM_GetGlobalDebug();
@@ -21,6 +95,10 @@ int main(int argc, char **argv)
 	GSM_SetDebugLevel("textall", debug_info);
 
 	error = CreateMessage(&type, &sms, argc, 1, argv, NULL);
+	if (invalid_input != NULL) {
+		gammu_test_result_code(error, "CreateMessage", ERR_INVALIDDATA);
+		return 0;
+	}
 	gammu_test_result(error, "CreateMessage");
 
 	DisplayMultiSMSInfo(&sms, FALSE, TRUE, NULL, NULL);

--- a/tests/utf-8.c
+++ b/tests/utf-8.c
@@ -5,9 +5,36 @@
 #include "common.h"
 #include <gammu.h>
 #include <gammu-unicode.h>
+#include <locale.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../libgammu/misc/coding/coding.h"
+
+static gboolean SetUTF8Locale(void)
+{
+    static const char *locales[] = {
+        "",
+        "C.UTF-8",
+        "C.utf8",
+        "en_US.UTF-8",
+        ".UTF-8",
+    };
+    size_t i;
+    wchar_t decoded;
+
+    for (i = 0; i < sizeof(locales) / sizeof(locales[0]); i++) {
+        if (setlocale(LC_CTYPE, locales[i]) == NULL || MB_CUR_MAX < 2) {
+            continue;
+        }
+        mbtowc(NULL, NULL, 0);
+        if (mbtowc(&decoded, "\xc3\xa9", 2) == 2 && decoded == 0xe9) {
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
 
 int main(int argc UNUSED, char **argv UNUSED)
 {
@@ -16,6 +43,17 @@ int main(int argc UNUSED, char **argv UNUSED)
     size_t i;
     const char input[] = "005400680061006E006B00200079006F0075002E002000570065002000770069006C006C00200063006F006E007400610063007400200079006F007500200073006F006F006E00200078006F0078006F00200078006F0078006F00200061006E0064002000490020D83DDE18D83DDE18D83DDE18D83DDE18D83DDE18D83DDE18D83DDE18D83D";
     const char expected[] = "Thank you. We will contact you soon xoxo xoxo and I 😘😘😘😘😘😘😘�";
+    const char invalid_locale[] = {'a', (char)0xc3, 'z', 0};
+    const char invalid_utf8[] = {'o', 'k', (char)0xff, 'r', 'e', 's', 't'};
+    const char invalid_continuation[] = {(char)0xc3, 'z'};
+    const char truncated_utf8[] = {(char)0xc3, (char)0xa9};
+    const unsigned char expected_replacement[] = {
+        0x00, 0x61, 0xff, 0xfd, 0x00, 0x7a, 0x00, 0x00
+    };
+    const unsigned char expected_truncated[] = {0xff, 0xfd, 0x00, 0x00};
+    const unsigned char expected_utf8_prefix[] = {
+        0x00, 0x6f, 0x00, 0x6b, 0x00, 0x00
+    };
 
     test_result(EncodeWithUTF8Alphabet(0x24, out) == 1);
     test_result(out[0] == 0x24);
@@ -60,6 +98,13 @@ int main(int argc UNUSED, char **argv UNUSED)
 
     test_string("\x00\x61\x00h\x00o\x00j\x00\x00\x00", out, 10);
 
+    test_result(DecodeUTF8Checked(out, "ahoj", 4));
+    test_result(!DecodeUTF8Checked(out, invalid_utf8,
+                                   sizeof(invalid_utf8)));
+    test_string(expected_utf8_prefix, out, sizeof(expected_utf8_prefix));
+    test_result(!DecodeUTF8Checked(out, invalid_continuation,
+                                   sizeof(invalid_continuation)));
+
     /* Decode hex encoded unicode */
     test_result(DecodeHexUnicode(out, input, strlen(input)));
     test_string("\x00T\x00h\x00\x61\x00n\x00k\x00", out, 10);
@@ -67,6 +112,15 @@ int main(int argc UNUSED, char **argv UNUSED)
     /* Convert it to UTF-8 */
     test_result(EncodeUTF8(out2, out));
     test_string(expected, out2, strlen(expected));
+
+    if (SetUTF8Locale()) {
+        test_result(!EncodeUnicodeChecked(out, truncated_utf8, 1));
+        test_string(expected_truncated, out, sizeof(expected_truncated));
+        test_result(!EncodeUnicodeChecked(out, invalid_locale,
+                                          sizeof(invalid_locale) - 1));
+        test_string(expected_replacement, out,
+                    sizeof(expected_replacement));
+    }
 
     return 0;
 }


### PR DESCRIPTION
Invalid multibyte input under the process locale became U+0000 and silently cut messages at the first unsupported byte. Preserve the remaining text with U+FFFD, reject invalid command-line message text, and direct callers to -textutf8.

Closes #465