### PR TITLE
fix(smsd): align SQL phone heartbeat with status refresh

### DIFF
--- a/docs/manual/smsd/config.rst
+++ b/docs/manual/smsd/config.rst
@@ -210,6 +210,9 @@ General parameters of SMS daemon
     The number of seconds between refreshing phone status (battery, signal) stored
     in shared memory and possibly in service backends. Use 0 to disable.
 
+    With the default SQL queries, the phone record expires ten seconds after
+    the next refresh is due.
+
     You might want to increase this for higher throughput.
 
     Default is 60.

--- a/docs/manual/smsd/sql.rst
+++ b/docs/manual/smsd/sql.rst
@@ -172,8 +172,15 @@ are selected for default queries during initialization.
 
     .. code-block:: sql
 
-        INSERT INTO phones (IMEI, ID, Send, Receive, InsertIntoDB, TimeOut, Client, Battery, Signal)
-        VALUES (%I, %P, %1, %2, NOW(), (NOW() + INTERVAL 10 SECOND) + 0, %N, -1, -1)
+        INSERT INTO phones (IMEI, IMSI, ID, NetCode, NetName, Send, Receive,
+                            InsertIntoDB, TimeOut, Client, Battery, Signal)
+        VALUES (%I, %S, %P, %O, %M, %1, %2, NOW(),
+                (NOW() + INTERVAL 70 SECOND) + 0, %N, -1, -1)
+
+    The shown 70-second expiry uses the default 60-second
+    :config:option:`StatusFrequency` plus a ten-second grace period. The
+    generated default query follows the configured frequency. Custom queries
+    should provide an equivalent expiry interval.
 
     Query specific parameters:
 
@@ -538,14 +545,19 @@ are selected for default queries during initialization.
 
 .. config:option:: refresh_phone_status
 
-    Update phone status (battery, signal).
+    Update phone status (battery, signal, and network).
 
     Default value:
 
     .. code-block:: sql
 
-        UPDATE phones SET TimeOut= (NOW() + INTERVAL 10 SECOND) + 0,
-        Battery = %1, Signal = %2 WHERE IMEI = %I
+        UPDATE phones SET TimeOut = (NOW() + INTERVAL 70 SECOND) + 0,
+        Battery = %1, Signal = %2, NetCode = %O, NetName = %M
+        WHERE IMEI = %I
+
+    The expiry interval is generated from :config:option:`StatusFrequency`
+    plus a ten-second grace period, as described for :config:option:`insert_phone`.
+    Custom queries should keep ``TimeOut`` valid through the next refresh.
 
     Query specific parameters:
 

--- a/docs/manual/smsd/tables.rst
+++ b/docs/manual/smsd/tables.rst
@@ -323,7 +323,10 @@ Fields description:
     when this record has been created (when phone has been connected)
 
 ``TimeOut`` (timestamp)
-    when this record expires
+    when this record expires. With the default SQL queries, this is ten seconds
+    after the next :config:option:`StatusFrequency` refresh is due. A record
+    with a value older than the database server's current time indicates a
+    stale SMSD phone heartbeat.
 
 ``Send`` (boolean)
     indicates whether SMSD is sending messages, depends on configuration directive :config:option:`Send`
@@ -337,6 +340,12 @@ Fields description:
 ``IMSI`` (text)
     SIM IMSI
 
+``NetCode`` (text)
+    code of the network the phone is registered to
+
+``NetName`` (text)
+    name of the network the phone is registered to
+
 ``Client`` (text)
     client name, usually string Gammu with version
 
@@ -347,12 +356,12 @@ Fields description:
     signal level in percent (or \-1 if unknown)
 
 ``Sent`` (integer)
-    Number of sent SMS messages (SMSD does not reset this counter, so it might
-    overflow).
+    Number of sent SMS messages since the SQL service created this phone
+    record. The default SQL queries recreate the record when SMSD starts.
 
 ``Received`` (integer)
-    Number of received SMS messages (SMSD does not reset this counter, so it might
-    overflow).
+    Number of received SMS messages since the SQL service created this phone
+    record. The default SQL queries recreate the record when SMSD starts.
 
 .. _sentitems:
 

--- a/smsd/services/sql.c
+++ b/smsd/services/sql.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #include <time.h>
 #ifdef WIN32
 #include <windows.h>
@@ -47,7 +48,7 @@ const char now_plus_mysql[] = "(NOW() + INTERVAL %d SECOND) + 0";
 const char now_plus_pgsql[] = "now() + interval '%d seconds'";
 const char now_plus_sqlite[] = "datetime('now', '+%d seconds', 'localtime')";
 const char now_plus_freetds[] = "DATEADD(second, %d, CURRENT_TIMESTAMP)";
-const char now_plus_access[] = "now()+#00:00:%d#";
+const char now_plus_access[] = "DateAdd('s', %d, Now())";
 const char now_plus_oracle[] = "CURRENT_TIMESTAMP + NUMTODSINTERVAL(%d, 'SECOND')";
 const char now_plus_fallback[] = "NOW() + INTERVAL %d SECOND";
 
@@ -61,7 +62,7 @@ const char now_minus_oracle[] = "CURRENT_TIMESTAMP - NUMTODSINTERVAL(%d, 'SECOND
 const char now_minus_fallback[] = "NOW() - INTERVAL %d SECOND";
 
 
-static const char *SMSDSQL_NowPlus(GSM_SMSDConfig * Config, int seconds)
+const char *SMSDSQL_NowPlus(GSM_SMSDConfig * Config, int seconds)
 {
 	const char *driver_name;
 	static char result[100];
@@ -86,6 +87,14 @@ static const char *SMSDSQL_NowPlus(GSM_SMSDConfig * Config, int seconds)
 		snprintf(result, sizeof(result), now_plus_fallback, seconds);
 	}
 	return result;
+}
+
+int SMSDSQL_PhoneStatusTimeout(unsigned int status_frequency)
+{
+	if (status_frequency > INT_MAX - 10) {
+		return INT_MAX;
+	}
+	return (int)status_frequency + 10;
 }
 
 static const char *SMSDSQL_NowMinus(GSM_SMSDConfig *Config, int seconds)
@@ -2193,7 +2202,7 @@ GSM_Error SMSDSQL_option(GSM_SMSDConfig *Config, int optint, const char *option,
  */
 GSM_Error SMSDSQL_ReadConfiguration(GSM_SMSDConfig *Config)
 {
-	int locktime;
+	int locktime, phone_timeout;
 	const char *escape_char;
 
 	Config->inbox_groups = NULL;
@@ -2300,6 +2309,7 @@ GSM_Error SMSDSQL_ReadConfiguration(GSM_SMSDConfig *Config)
 
 	locktime = Config->loopsleep * 8; /* reserve 8 sec per message */
 	locktime = locktime < 60 ? 60 : locktime; /* Minimum time reserve is 60 sec */
+	phone_timeout = SMSDSQL_PhoneStatusTimeout(Config->statusfrequency);
 
 	if (SMSDSQL_option(Config, SQL_QUERY_DELETE_PHONE, "delete_phone",
 		"DELETE FROM ", Config->table_phones, " WHERE ", ESCAPE_FIELD("IMEI"), " = %I", NULL) != ERR_NONE) {
@@ -2323,7 +2333,7 @@ GSM_Error SMSDSQL_ReadConfiguration(GSM_SMSDConfig *Config)
 			") VALUES (%I, %S, %P, %O, %M, %1, %2, ",
 			SMSDSQL_Now(Config),
 			", ",
-			SMSDSQL_NowPlus(Config, 10),
+			SMSDSQL_NowPlus(Config, phone_timeout),
 			", %N, -1, -1)", NULL) != ERR_NONE) {
 		return ERR_UNKNOWN;
 	}
@@ -2622,7 +2632,7 @@ GSM_Error SMSDSQL_ReadConfiguration(GSM_SMSDConfig *Config)
 
 	if (SMSDSQL_option(Config, SQL_QUERY_REFRESH_PHONE_STATUS, "refresh_phone_status",
 		"UPDATE ", Config->table_phones, " SET ",
-			ESCAPE_FIELD("TimeOut"), "= ", SMSDSQL_NowPlus(Config, 10),
+			ESCAPE_FIELD("TimeOut"), "= ", SMSDSQL_NowPlus(Config, phone_timeout),
 			", ", ESCAPE_FIELD("Battery"), " = %1"
 			", ", ESCAPE_FIELD("Signal"), " = %2"
 			", ", ESCAPE_FIELD("NetCode"), " = %O"

--- a/smsd/services/sql.h
+++ b/smsd/services/sql.h
@@ -8,6 +8,16 @@
 extern GSM_SMSDService SMSDSQL;
 
 /**
+ * Formats a database-specific expression adding seconds to current time.
+ */
+const char *SMSDSQL_NowPlus(GSM_SMSDConfig * Config, int seconds);
+
+/**
+ * Returns phone status expiry interval including the heartbeat grace period.
+ */
+int SMSDSQL_PhoneStatusTimeout(unsigned int status_frequency);
+
+/**
  * Parses date string into time_t.
  *
  * \return Negative value on failure, -2 for special date "0000-00-00 00:00:00"

--- a/tests/sql-read-order.c
+++ b/tests/sql-read-order.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <limits.h>
 
 #include <gammu.h>
 #include <gammu-smsd.h>
@@ -550,6 +551,33 @@ static void setup_config(GSM_SMSDConfig *config)
 	config->SMSDSQL_queries[SQL_QUERY_SAVE_INBOX_SMS_UPDATE_METADATA] = query_inbox_metadata;
 	config->SMSDSQL_queries[SQL_QUERY_RESTORE_INBOX_GROUPS] = query_restore_inbox_groups;
 	config->SMSDSQL_queries[SQL_QUERY_UPDATE_RECEIVED] = query_update_received;
+}
+
+static void test_phone_status_timeout(void)
+{
+	GSM_SMSDConfig config;
+
+	setup_config(&config);
+
+	test_result(SMSDSQL_PhoneStatusTimeout(0) == 10);
+	test_result(SMSDSQL_PhoneStatusTimeout(60) == 70);
+	test_result(SMSDSQL_PhoneStatusTimeout(UINT_MAX) == INT_MAX);
+
+	config.sql = "mysql";
+	test_result(strcmp(SMSDSQL_NowPlus(&config, 70),
+			"(NOW() + INTERVAL 70 SECOND) + 0") == 0);
+	config.sql = "pgsql";
+	test_result(strcmp(SMSDSQL_NowPlus(&config, 70),
+			"now() + interval '70 seconds'") == 0);
+	config.sql = "sqlite3";
+	test_result(strcmp(SMSDSQL_NowPlus(&config, 70),
+			"datetime('now', '+70 seconds', 'localtime')") == 0);
+	config.sql = "access";
+	test_result(strcmp(SMSDSQL_NowPlus(&config, 70),
+			"DateAdd('s', 70, Now())") == 0);
+	config.sql = "mssql";
+	test_result(strcmp(SMSDSQL_NowPlus(&config, 70),
+			"DATEADD(second, 70, CURRENT_TIMESTAMP)") == 0);
 }
 
 static void test_find_outbox_order(void)
@@ -1430,6 +1458,7 @@ static void test_send_reconciliation_error_is_left_queued(void)
 
 int main(void)
 {
+	test_phone_status_timeout();
 	test_find_outbox_order();
 	test_find_outbox_without_sent_item();
 	test_matching_sent_item_is_skipped();


### PR DESCRIPTION
Keep phones.TimeOut valid until the next scheduled status refresh plus the existing grace period. Document the complete phone status queries and row lifetime for database monitoring.

Closes #384

Closes #439