### PR TITLE
fix(gnapgen): encode work phone numbers correctly

### DIFF
--- a/libgammu/phone/symbian/gnapgen.c
+++ b/libgammu/phone/symbian/gnapgen.c
@@ -1085,7 +1085,7 @@ static GSM_Error GNAPGEN_SetMemory (GSM_StateMachine *s, GSM_MemoryEntry *entry)
 					req[currentByte++] = 0x0b;
 					req[currentByte++] = 0x00;
 					req[currentByte++] = 0x02;
-				} else if (subMemoryEntry->Location == PBK_Location_Home) {
+				} else if (subMemoryEntry->Location == PBK_Location_Work) {
 					req[currentByte++] = 0x00;
 					req[currentByte++] = 0x0b;
 					req[currentByte++] = 0x00;


### PR DESCRIPTION
The work-number branch repeated the home-location check, leaving it unreachable and encoding work numbers as generic mobile numbers.

Closes #446