### PR TITLE
fix(smsd): honor monitor logging option

### DIFF
--- a/docs/manual/smsd/monitor.rst
+++ b/docs/manual/smsd/monitor.rst
@@ -51,12 +51,17 @@ accepted on some platforms):
 
     .. code-block:: text
 
-        client;phone ID;IMEI;sent;received;failed;battery;signal
+        client;phone ID;IMEI;IMSI;sent;received;failed;battery;signal
+
+    CSV status records are always written to standard output and are not given
+    logging prefixes, including when :option:`--use-log` is specified.
 
 .. option:: -l, --use-log
 
-    Use logging as configured in config file.
+    Write human-readable status updates using the logging configuration from
+    the config file.
 
 .. option:: -L, --no-use-log
 
-    Do not use logging as configured in config file (default).
+    Write human-readable status updates to standard output (default). Output is
+    flushed after every polling cycle so it can be consumed by a pipeline.

--- a/smsd/monitor.c
+++ b/smsd/monitor.c
@@ -17,6 +17,7 @@
 #endif
 
 #include "common.h"
+#include "log.h"
 
 #if !defined(WIN32) && (defined(HAVE_GETOPT) || defined(HAVE_GETOPT_LONG))
 #define HAVE_DEFAULT_CONFIG
@@ -190,6 +191,48 @@ void process_commandline(int argc, char **argv, SMSD_Parameters * params)
 #ifndef WIN32
 #endif
 
+static void print_status(GSM_SMSDConfig *config, const GSM_SMSDStatus *status,
+			 gboolean use_log)
+{
+	if (compact) {
+		printf("%s;%s;%s;%s;%d;%d;%d;%d;%d\n",
+		       status->Client,
+		       status->PhoneID,
+		       status->IMEI,
+		       status->IMSI,
+		       status->Sent,
+		       status->Received,
+		       status->Failed,
+		       status->Charge.BatteryPercent,
+		       status->Network.SignalPercent);
+		fflush(stdout);
+	} else if (use_log) {
+		SMSD_Log(DEBUG_INFO, config,
+			 "Status: Client=\"%s\", PhoneID=\"%s\", IMEI=\"%s\", IMSI=\"%s\", Sent=%d, Received=%d, Failed=%d, BatteryPercent=%d, NetworkSignal=%d",
+			 status->Client,
+			 status->PhoneID,
+			 status->IMEI,
+			 status->IMSI,
+			 status->Sent,
+			 status->Received,
+			 status->Failed,
+			 status->Charge.BatteryPercent,
+			 status->Network.SignalPercent);
+	} else {
+		printf("Client: %s\n", status->Client);
+		printf("PhoneID: %s\n", status->PhoneID);
+		printf("IMEI: %s\n", status->IMEI);
+		printf("IMSI: %s\n", status->IMSI);
+		printf("Sent: %d\n", status->Sent);
+		printf("Received: %d\n", status->Received);
+		printf("Failed: %d\n", status->Failed);
+		printf("BatterPercent: %d\n", status->Charge.BatteryPercent);
+		printf("NetworkSignal: %d\n", status->Network.SignalPercent);
+		printf("\n");
+		fflush(stdout);
+	}
+}
+
 int main(int argc, char **argv)
 {
 	GSM_Error error;
@@ -255,29 +298,7 @@ int main(int argc, char **argv)
 			SMSD_FreeConfig(config);
 			return 3;
 		}
-		if (compact) {
-			printf("%s;%s;%s;%s;%d;%d;%d;%d;%d\n",
-				 status.Client,
-				 status.PhoneID,
-				 status.IMEI,
-				 status.IMSI,
-				 status.Sent,
-				 status.Received,
-				 status.Failed,
-				 status.Charge.BatteryPercent,
-				 status.Network.SignalPercent);
-		} else {
-			printf("Client: %s\n", status.Client);
-			printf("PhoneID: %s\n", status.PhoneID);
-			printf("IMEI: %s\n", status.IMEI);
-			printf("IMSI: %s\n", status.IMSI);
-			printf("Sent: %d\n", status.Sent);
-			printf("Received: %d\n", status.Received);
-			printf("Failed: %d\n", status.Failed);
-			printf("BatterPercent: %d\n", status.Charge.BatteryPercent);
-			printf("NetworkSignal: %d\n", status.Network.SignalPercent);
-			printf("\n");
-		}
+		print_status(config, &status, params.use_log);
 		sleep(delay_seconds);
 	}
 

--- a/smsd/test-smsd.sh.in
+++ b/smsd/test-smsd.sh.in
@@ -243,7 +243,25 @@ done
 
 sleep 5
 
-$SMSD_MONITOR_CMD -C -c "$CONFIG_PATH" -n 1 -d 0
+MONITOR_CSV=`$SMSD_MONITOR_CMD -C -c "$CONFIG_PATH" -n 1 -d 0`
+echo "$MONITOR_CSV"
+
+MONITOR_SENT=`echo "$MONITOR_CSV" | cut -d ';' -f 5`
+MONITOR_RECEIVED=`echo "$MONITOR_CSV" | cut -d ';' -f 6`
+MONITOR_FAILED=`echo "$MONITOR_CSV" | cut -d ';' -f 7`
+
+MONITOR_OUTPUT=`$SMSD_MONITOR_CMD -c "$CONFIG_PATH" -n 1 -d 0`
+echo "$MONITOR_OUTPUT"
+echo "$MONITOR_OUTPUT" | grep -q "^Sent: $MONITOR_SENT\$"
+echo "$MONITOR_OUTPUT" | grep -q "^Received: $MONITOR_RECEIVED\$"
+echo "$MONITOR_OUTPUT" | grep -q "^Failed: $MONITOR_FAILED\$"
+
+cp "$CONFIG_PATH" "$CONFIG_PATH.monitor-backup"
+sed 's/^logfile = stderr$/logfile = monitor.log/' "$CONFIG_PATH.monitor-backup" > "$CONFIG_PATH"
+rm -f monitor.log
+$SMSD_MONITOR_CMD -l -c "$CONFIG_PATH" -n 1 -d 0
+grep -q "Sent=$MONITOR_SENT, Received=$MONITOR_RECEIVED, Failed=$MONITOR_FAILED" monitor.log
+cp "$CONFIG_PATH.monitor-backup" "$CONFIG_PATH"
 
 if [ `wc -l < @CMAKE_CURRENT_BINARY_DIR@/smsd-test-$SERVICE/received.log` -ne $((8 + $INCOMING_USSD)) ] ; then
     echo "ERROR: Wrong number of messages received!"


### PR DESCRIPTION
Route human-readable status through the configured logger so monitor output follows SMSD logging policy. Keep CSV output unprefixed and flush stdout each cycle for reliable pipeline consumption.

Closes #473