### PR TITLE
fix(build): silence modern CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@
 
 cmake_minimum_required (VERSION 3.10)
 
+# Allow special characters in test names on CMake versions which support them.
+if (POLICY CMP0110)
+    cmake_policy (SET CMP0110 NEW)
+endif ()
+
 # Let modern linkers discard duplicate static libraries from transitive
 # dependencies.  Among other things, this avoids duplicate-library warnings
 # from recent Apple linkers.

--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -67,7 +67,7 @@ include(FindPackageHandleStandardArgs)
 find_program(LCOV_BIN lcov)
 find_program(GENINFO_BIN geninfo)
 find_program(GENHTML_BIN genhtml)
-find_package_handle_standard_args(lcov
+find_package_handle_standard_args(Lcov
 	REQUIRED_VARS LCOV_BIN GENINFO_BIN GENHTML_BIN
 )
 

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -26,18 +26,20 @@ if(UNIX)
     if(MYSQL_CONFIG)
         message(STATUS "Using mysql-config: ${MYSQL_CONFIG}")
         # set INCLUDE_DIR
-        exec_program(${MYSQL_CONFIG}
-            ARGS --include
-            OUTPUT_VARIABLE MY_TMP)
+        execute_process(
+            COMMAND "${MYSQL_CONFIG}" --include
+            OUTPUT_VARIABLE MY_TMP
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
 
         string(REGEX REPLACE "-I([^ ]+)( .*)?" "\\1" MY_TMP "${MY_TMP}")
 
         set(MYSQL_ADD_INCLUDE_DIR ${MY_TMP} CACHE FILEPATH INTERNAL)
 
         # set LIBRARY_DIR
-        exec_program(${MYSQL_CONFIG}
-            ARGS --libs
-            OUTPUT_VARIABLE MY_TMP)
+        execute_process(
+            COMMAND "${MYSQL_CONFIG}" --libs
+            OUTPUT_VARIABLE MY_TMP
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
 
         set(MYSQL_ADD_LIBRARIES "")
 

--- a/cmake/FindPostgres.cmake
+++ b/cmake/FindPostgres.cmake
@@ -46,9 +46,10 @@ ELSE(WIN32)
 
     IF (POSTGRES_CONFIG)
       # set INCLUDE_DIR
-      EXEC_PROGRAM(${POSTGRES_CONFIG}
-        ARGS --includedir
-        OUTPUT_VARIABLE PG_TMP)
+      execute_process(
+        COMMAND "${POSTGRES_CONFIG}" --includedir
+        OUTPUT_VARIABLE PG_TMP
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
     ELSE(POSTGRES_CONFIG)
       SET(PG_TMP /opt/postgresql)
     ENDIF(POSTGRES_CONFIG)
@@ -69,9 +70,14 @@ ELSE(WIN32)
       )
 
       # set LIBRARY_DIR
-      EXEC_PROGRAM(${POSTGRES_CONFIG}
-        ARGS --libdir
-        OUTPUT_VARIABLE PG_TMP)
+      IF (POSTGRES_CONFIG)
+        execute_process(
+          COMMAND "${POSTGRES_CONFIG}" --libdir
+          OUTPUT_VARIABLE PG_TMP
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+      ELSE(POSTGRES_CONFIG)
+        SET(PG_TMP /opt/postgresql)
+      ENDIF(POSTGRES_CONFIG)
       find_library(POSTGRES_LIBRARY pq
         PATHS
         ${PG_TMP}


### PR DESCRIPTION
Keep configuration clean on newer CMake releases by aligning package naming, opting into special-character test names, and replacing deprecated process execution APIs.