### PR TITLE
fix(smsd): avoid resending read-only outbox files

### DIFF
--- a/smsd/services/files.c
+++ b/smsd/services/files.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <limits.h>
 #include <time.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -14,6 +15,8 @@
 
 #ifdef WIN32
 #include <io.h>
+#else
+#include <unistd.h>
 #endif
 #if defined HAVE_DIRENT_H && defined HAVE_SCANDIR && defined HAVE_ALPHASORT
 #define HAVE_DIRBROWSING
@@ -281,6 +284,8 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	_findclose(hFile);
 #elif defined(HAVE_DIRBROWSING)
 	struct dirent **namelist = NULL;
+	struct stat entryStatus;
+	int outboxFd;
 	int cur_file, num_files;
 	char *pos;
 
@@ -290,6 +295,10 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 	}
 
 	FullName[strlen(Config->outboxpath) - 1] = '\0';
+	outboxFd = open(FullName, O_RDONLY | O_DIRECTORY);
+	if (outboxFd < 0) {
+		return ERR_CANTOPENFILE;
+	}
 
 	num_files = scandir(FullName, &namelist, 0, alphasort);
 
@@ -308,16 +317,27 @@ static GSM_Error SMSDFiles_FindOutboxSMS(GSM_MultiSMSMessage * sms, GSM_SMSDConf
 			continue;
 		}
 		if (strncasecmp(pos, ".txt", 4) == 0) {
+			if (fstatat(outboxFd, namelist[cur_file]->d_name,
+				    &entryStatus, AT_SYMLINK_NOFOLLOW) != 0 ||
+			    !S_ISREG(entryStatus.st_mode)) {
+				continue;
+			}
 			/* We have found text file */
 			backup = FALSE;
 			break;
 		}
 		if (strncasecmp(pos, ".smsbackup", 10) == 0) {
+			if (fstatat(outboxFd, namelist[cur_file]->d_name,
+				    &entryStatus, AT_SYMLINK_NOFOLLOW) != 0 ||
+			    !S_ISREG(entryStatus.st_mode)) {
+				continue;
+			}
 			/* We have found a SMS backup file */
 			backup = TRUE;
 			break;
 		}
 	}
+	close(outboxFd);
 	/* Remember file name */
 	if (cur_file < num_files) {
 		if (strlen(namelist[cur_file]->d_name) >= sizeof(FileName)) {
@@ -752,15 +772,98 @@ fail:
 	return ERR_WRITING_FILE;
 }
 
-static GSM_Error SMSDFiles_AddSentSMSInfo(GSM_MultiSMSMessage * sms UNUSED, GSM_SMSDConfig * Config, char *ID UNUSED, int Part, GSM_SMSDSendingError err, int TPMR)
+static GSM_Error SMSDFiles_WriteSentSMSInfo(FILE *file, GSM_File *GSMFile,
+					    unsigned char *lineStart,
+					    unsigned char *suffix,
+					    size_t suffixLength, int TPMR)
 {
-	FILE *file;
-	GSM_File GSMFile;
-	GSM_Error error;
-	unsigned char FullPath[PATH_MAX];
-	unsigned char *lineStart, *lineEnd;
 	/* MessageReference TPMR maximum is "255" */
 	char MessageReferenceBuffer[sizeof("MessageReference = \n") + 4];
+
+	if (fwrite(GSMFile->Buffer, 1, lineStart - GSMFile->Buffer, file) !=
+	    (size_t)(lineStart - GSMFile->Buffer)) {
+		return ERR_WRITING_FILE;
+	}
+
+	snprintf(MessageReferenceBuffer, sizeof(MessageReferenceBuffer),
+		 "MessageReference = %d\n", TPMR);
+
+	if (fwrite(MessageReferenceBuffer, 1, strlen(MessageReferenceBuffer), file) !=
+	    strlen(MessageReferenceBuffer)) {
+		return ERR_WRITING_FILE;
+	}
+	if (suffixLength > 0 && fwrite(suffix, 1, suffixLength, file) != suffixLength) {
+		return ERR_WRITING_FILE;
+	}
+	return ERR_NONE;
+}
+
+#ifndef WIN32
+static GSM_Error SMSDFiles_ReadSentSMSInfo(int fd, GSM_File *GSMFile)
+{
+	ssize_t length;
+	unsigned char *buffer;
+
+	free(GSMFile->Buffer);
+	GSMFile->Buffer = NULL;
+	GSMFile->Used = 0;
+	for (;;) {
+		if (GSMFile->Used > (size_t)-1 - 1001) {
+			free(GSMFile->Buffer);
+			GSMFile->Buffer = NULL;
+			GSMFile->Used = 0;
+			return ERR_MOREMEMORY;
+		}
+		buffer = realloc(GSMFile->Buffer, GSMFile->Used + 1001);
+		if (buffer == NULL) {
+			free(GSMFile->Buffer);
+			GSMFile->Buffer = NULL;
+			GSMFile->Used = 0;
+			return ERR_MOREMEMORY;
+		}
+		GSMFile->Buffer = buffer;
+		do {
+			length = read(fd, GSMFile->Buffer + GSMFile->Used, 1000);
+		} while (length < 0 && errno == EINTR);
+		if (length < 0) {
+			free(GSMFile->Buffer);
+			GSMFile->Buffer = NULL;
+			GSMFile->Used = 0;
+			return ERR_CANTOPENFILE;
+		}
+		if (length == 0) {
+			break;
+		}
+		GSMFile->Used += (size_t)length;
+	}
+	GSMFile->Buffer[GSMFile->Used] = '\0';
+	return ERR_NONE;
+}
+#endif
+
+static GSM_Error SMSDFiles_AddSentSMSInfo(GSM_MultiSMSMessage * sms UNUSED, GSM_SMSDConfig * Config, char *ID UNUSED, int Part, GSM_SMSDSendingError err, int TPMR)
+{
+	FILE *file = NULL;
+	GSM_File GSMFile;
+	GSM_Error error;
+	int i;
+	int fd = -1;
+	unsigned char FullPath[PATH_MAX];
+	unsigned char *lineStart, *lineEnd, *suffix;
+	size_t suffixLength;
+	char TempPath[PATH_MAX];
+#ifdef WIN32
+	DWORD fileAttributes;
+	gboolean readOnlyCleared = FALSE;
+#else
+	int originalFd = -1;
+	int tempDirFd = -1;
+	struct stat fileStatus;
+	struct stat currentStatus;
+	struct stat tempDirStatus;
+#endif
+
+	TempPath[0] = '\0';
 
 	if (err == SMSD_SEND_OK) {
 		SMSD_Log(DEBUG_INFO, Config, "Transmitted %s (%s: %i) to %s, message reference 0x%02x",
@@ -775,10 +878,26 @@ static GSM_Error SMSDFiles_AddSentSMSInfo(GSM_MultiSMSMessage * sms UNUSED, GSM_
 	// Read file content
 	GSMFile.Buffer = NULL;
 	GSMFile.Used = 0;
+#ifdef WIN32
 	error = GSM_ReadFile(FullPath, &GSMFile);
+#else
+	originalFd = open((char *)FullPath, O_RDONLY | O_NOFOLLOW);
+	if (originalFd < 0 || fstat(originalFd, &fileStatus) != 0 ||
+	    !S_ISREG(fileStatus.st_mode)) {
+		SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to open original file");
+		if (originalFd >= 0) {
+			close(originalFd);
+		}
+		return ERR_CANTOPENFILE;
+	}
+	error = SMSDFiles_ReadSentSMSInfo(originalFd, &GSMFile);
+#endif
 
 	if (error != ERR_NONE) {
 		SMSD_Log(DEBUG_ERROR, Config, "AddSentSMSInfo: Failed to read file!");
+#ifndef WIN32
+		close(originalFd);
+#endif
 		free(GSMFile.Buffer);
 		return error;
 	}
@@ -787,53 +906,334 @@ static GSM_Error SMSDFiles_AddSentSMSInfo(GSM_MultiSMSMessage * sms UNUSED, GSM_
 	GSMFile.Buffer = realloc(GSMFile.Buffer, GSMFile.Used + 1);
 
 	if (GSMFile.Buffer == NULL) {
+#ifndef WIN32
+		close(originalFd);
+#endif
 		return ERR_MOREMEMORY;
 	}
 
 	GSMFile.Buffer[GSMFile.Used] = '\0';
 
-	lineStart = strstr(GSMFile.Buffer, "\nMessageReference = ");
+	lineStart = GSMFile.Buffer;
+	for (i = 0; i < Part; i++) {
+		lineStart = strstr(lineStart, "\nMessageReference = ");
+		if (lineStart == NULL) {
+#ifndef WIN32
+			close(originalFd);
+#endif
+			free(GSMFile.Buffer);
+			return ERR_NONE;
+		}
+		lineStart++;
+	}
 
-	/* Message reference not found */
-	if (lineStart == NULL) {
+	lineEnd = strchr(lineStart, '\n');
+	if (lineEnd == NULL) {
+		suffix = GSMFile.Buffer + GSMFile.Used;
+		suffixLength = 0;
+	} else {
+		suffix = lineEnd + 1;
+		suffixLength = GSMFile.Used - (suffix - GSMFile.Buffer);
+	}
+
+	/* Keep writable files on their original inode, as the files backend did
+	 * historically. Besides avoiding the need for another inode, this preserves
+	 * all metadata associated with the file. */
+	/* Open only the file that was read above. Using fopen("wb") here could
+	 * recreate it with default permissions if it disappeared in between. */
+#ifdef WIN32
+	fd = _open((char *)FullPath, _O_WRONLY | _O_BINARY);
+#else
+	fd = open((char *)FullPath, O_WRONLY);
+	if (fd >= 0) {
+		if (fstat(fd, &currentStatus) != 0 ||
+		    currentStatus.st_dev != fileStatus.st_dev ||
+		    currentStatus.st_ino != fileStatus.st_ino) {
+			SMSD_Log(DEBUG_ERROR, Config,
+				 "AddSentSMSInfo: Outbox entry changed while being processed");
+			close(fd);
+			fd = -1;
+			errno = EAGAIN;
+			goto fail;
+		}
+	}
+#endif
+	if (fd >= 0) {
+		file = fdopen(fd, "wb");
+		if (file == NULL) {
+			goto fail;
+		}
+		fd = -1;
+#ifdef WIN32
+		if (_chsize(fileno(file), 0) != 0) {
+#else
+		/* fdopen does not truncate an existing descriptor. Do this only after
+		 * the stream has been allocated so allocation failure leaves the
+		 * successfully sent outbox entry intact. */
+		if (ftruncate(fileno(file), 0) != 0) {
+#endif
+			goto fail;
+		}
+		error = SMSDFiles_WriteSentSMSInfo(file, &GSMFile, lineStart, suffix,
+						       suffixLength, TPMR);
+		if (error != ERR_NONE) {
+			goto fail;
+		}
+		if (fclose(file) != 0) {
+			file = NULL;
+			goto close_failure;
+		}
+		file = NULL;
+#ifndef WIN32
+		close(originalFd);
+		originalFd = -1;
+#endif
 		free(GSMFile.Buffer);
 		return ERR_NONE;
 	}
-	lineStart++;
-	lineEnd = strchr(GSMFile.Buffer, '\n');
-	/* End of buffer? */
-	if (lineEnd == NULL) {
-		lineEnd = GSMFile.Buffer + GSMFile.Used;
-	}
 
-	file = fopen(FullPath, "w");
-	if (file == NULL) {
-		SMSD_LogErrno(Config,  "AddSentSMSInfo: Failed to open file for writing");
+#ifdef WIN32
+	fileAttributes = GetFileAttributesA((char *)FullPath);
+	if (fileAttributes == INVALID_FILE_ATTRIBUTES) {
+		SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to get file attributes");
 		free(GSMFile.Buffer);
 		return ERR_CANTOPENFILE;
 	}
+#endif
 
-	chk_fwrite(GSMFile.Buffer, lineStart - GSMFile.Buffer, 1, file);
+	/* This basename is no longer than the shortest valid outbox filename
+	 * (OUT.txt), and cannot be picked up by an OUT* scanner after a crash. */
+	error = SMSDFiles_BuildPath(TempPath, sizeof(TempPath), Config->outboxpath,
+				    ".XXXXXX", Config);
+	if (error != ERR_NONE) {
+#ifndef WIN32
+		close(originalFd);
+#endif
+		free(GSMFile.Buffer);
+		return error;
+	}
+#ifdef WIN32
+	if (_mktemp_s(TempPath, sizeof(TempPath)) != 0) {
+		SMSD_Log(DEBUG_ERROR, Config, "AddSentSMSInfo: Failed to create temporary filename");
+		free(GSMFile.Buffer);
+		return ERR_CANTOPENFILE;
+	}
+	fd = _open(TempPath, _O_WRONLY | _O_CREAT | _O_EXCL | _O_BINARY,
+		   _S_IREAD | _S_IWRITE);
+#else
+	/* Keep the replacement in a private directory and address it through the
+	 * directory descriptor. Submitters with access to the outbox parent can
+	 * rename that directory, but cannot swap the entry used by linkat. */
+	if (mkdtemp(TempPath) == NULL) {
+		SMSD_Log(DEBUG_ERROR, Config,
+			 "AddSentSMSInfo: Failed to create temporary directory: %s",
+			 strerror(errno));
+		close(originalFd);
+		free(GSMFile.Buffer);
+		return ERR_CANTOPENFILE;
+	}
+	tempDirFd = open(TempPath, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+	if (tempDirFd < 0 || fstat(tempDirFd, &tempDirStatus) != 0 ||
+	    !S_ISDIR(tempDirStatus.st_mode) ||
+	    tempDirStatus.st_uid != geteuid() ||
+	    (tempDirStatus.st_mode & 077) != 0) {
+		SMSD_Log(DEBUG_ERROR, Config,
+			 "AddSentSMSInfo: Failed to open the created temporary directory");
+		errno = EAGAIN;
+		goto fail;
+	}
+	fd = openat(tempDirFd, "message", O_WRONLY | O_CREAT | O_EXCL, 0600);
+#endif
+	if (fd < 0) {
+		SMSD_Log(DEBUG_ERROR, Config,
+			 "AddSentSMSInfo: Failed to create temporary file: %s", strerror(errno));
+#ifndef WIN32
+		if (tempDirFd >= 0) {
+			close(tempDirFd);
+			tempDirFd = -1;
+			if (rmdir(TempPath) == 0) {
+				TempPath[0] = '\0';
+			} else {
+				SMSD_Log(DEBUG_INFO, Config,
+					 "AddSentSMSInfo: Leaving temporary directory after create failure: %s",
+					 TempPath);
+			}
+		}
+		close(originalFd);
+#endif
+		free(GSMFile.Buffer);
+		return ERR_CANTOPENFILE;
+	}
+#ifndef WIN32
+	/* Replacing a non-writable inode only attempts to preserve its basic
+	 * ownership and mode metadata. */
+	if (fchown(fd, fileStatus.st_uid, fileStatus.st_gid) != 0) {
+		SMSD_Log(DEBUG_INFO, Config,
+			 "AddSentSMSInfo: Could not preserve file ownership: %s", strerror(errno));
+	}
+	if (fchmod(fd, fileStatus.st_mode & 07777) != 0) {
+		SMSD_Log(DEBUG_INFO, Config,
+			 "AddSentSMSInfo: Could not preserve file permissions: %s", strerror(errno));
+	}
+#endif
+	file = fdopen(fd, "wb");
+	if (file == NULL) {
+		SMSD_Log(DEBUG_ERROR, Config,
+			 "AddSentSMSInfo: Failed to open temporary file: %s", strerror(errno));
+		goto fail;
+	}
+	fd = -1;
 
-	snprintf(MessageReferenceBuffer, sizeof(MessageReferenceBuffer),
-		 "MessageReference = %d\n", TPMR);
+	error = SMSDFiles_WriteSentSMSInfo(file, &GSMFile, lineStart, suffix,
+					       suffixLength, TPMR);
+	if (error != ERR_NONE) {
+		goto fail;
+	}
+	if (fclose(file) != 0) {
+		file = NULL;
+		goto close_failure;
+	}
+	file = NULL;
 
+#ifdef WIN32
+	if ((fileAttributes & FILE_ATTRIBUTE_READONLY) != 0) {
+		DWORD writableAttributes = fileAttributes & ~FILE_ATTRIBUTE_READONLY;
 
-	chk_fwrite(MessageReferenceBuffer, strlen(MessageReferenceBuffer), 1, file);
+		if (writableAttributes == 0) {
+			writableAttributes = FILE_ATTRIBUTE_NORMAL;
+		}
+		if (!SetFileAttributesA((char *)FullPath,
+					writableAttributes)) {
+			SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to clear read-only attribute");
+			goto fail;
+		}
+		readOnlyCleared = TRUE;
+	}
+	if (!ReplaceFileA((char *)FullPath, TempPath, NULL, 0, NULL, NULL)) {
+		DWORD replaceError = GetLastError();
 
-	chk_fwrite(lineEnd + 1, (GSMFile.Buffer - lineEnd) + GSMFile.Used - 1, 1, file);
+		if (readOnlyCleared) {
+			DWORD currentAttributes = GetFileAttributesA((char *)FullPath);
 
-	fclose(file);
+			if (currentAttributes != INVALID_FILE_ATTRIBUTES) {
+				SetFileAttributesA((char *)FullPath,
+						   currentAttributes | FILE_ATTRIBUTE_READONLY);
+			}
+		}
+		SetLastError(replaceError);
+		SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to replace file");
+		goto fail;
+	}
+	TempPath[0] = '\0';
+#else
+	/* Atomically claim the current directory entry in the protected directory,
+	 * then verify that it is the inode read above. This avoids a check/use gap
+	 * at FullPath: a replacement submitted before this rename is preserved in
+	 * the private directory rather than overwritten. */
+	if (renameat(AT_FDCWD, (char *)FullPath, tempDirFd, "original") != 0) {
+		SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to claim original file");
+		goto fail;
+	}
+	if (fstatat(tempDirFd, "original", &currentStatus,
+		    AT_SYMLINK_NOFOLLOW) != 0 ||
+	    currentStatus.st_dev != fileStatus.st_dev ||
+	    currentStatus.st_ino != fileStatus.st_ino) {
+		SMSD_Log(DEBUG_ERROR, Config,
+			 "AddSentSMSInfo: Outbox entry changed before replacement");
+		/* Restore the claimed entry only if no newer producer has reused the
+		 * pathname. Otherwise leave it protected for manual recovery. */
+		if (linkat(tempDirFd, "original", AT_FDCWD,
+			   (char *)FullPath, 0) == 0) {
+			unlinkat(tempDirFd, "original", 0);
+		}
+		errno = EAGAIN;
+		goto fail;
+	}
+	/* linkat fails rather than overwriting a message submitted after the claim.
+	 * Both source names are protected by tempDirFd. */
+	if (linkat(tempDirFd, "message", AT_FDCWD, (char *)FullPath, 0) != 0) {
+		int replaceError = errno;
+
+		SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to replace file");
+		/* The claim removed FullPath. Put the original entry back whenever no
+		 * producer has occupied that pathname in the meantime. */
+		if (linkat(tempDirFd, "original", AT_FDCWD,
+			   (char *)FullPath, 0) == 0) {
+			unlinkat(tempDirFd, "original", 0);
+		}
+		errno = replaceError;
+		goto fail;
+	}
+	if (unlinkat(tempDirFd, "message", 0) != 0) {
+		SMSD_LogErrno(Config,
+				 "AddSentSMSInfo: Failed to unlink temporary replacement");
+	}
+	if (unlinkat(tempDirFd, "original", 0) != 0) {
+		SMSD_LogErrno(Config,
+				 "AddSentSMSInfo: Failed to unlink replaced original");
+	}
+	close(tempDirFd);
+	tempDirFd = -1;
+	if (rmdir(TempPath) != 0) {
+		SMSD_Log(DEBUG_INFO, Config,
+			 "AddSentSMSInfo: Could not remove temporary directory: %s",
+			 strerror(errno));
+	}
+	TempPath[0] = '\0';
+	close(originalFd);
+	originalFd = -1;
+#endif
 
 	free(GSMFile.Buffer);
 	return ERR_NONE;
 fail:
-	SMSD_LogErrno(Config,  "AddSentSMSInfo: Failed to write");
+	SMSD_LogErrno(Config, "AddSentSMSInfo: Failed to write");
 	if (file) {
 		fclose(file);
 	}
+	if (fd >= 0) {
+#ifdef WIN32
+		_close(fd);
+#else
+		close(fd);
+#endif
+	}
+#ifndef WIN32
+	if (tempDirFd >= 0) {
+		close(tempDirFd);
+	}
+	if (originalFd >= 0) {
+		close(originalFd);
+	}
+#endif
+	if (TempPath[0] != '\0') {
+		/* The outbox directory can be writable by message submitters. Leave the
+		 * hidden temporary entry for safe manual cleanup rather than deleting a
+		 * pathname that might have been swapped. */
+		SMSD_Log(DEBUG_INFO, Config,
+			 "AddSentSMSInfo: Leaving temporary file after failure: %s",
+			 TempPath);
+	}
 	free(GSMFile.Buffer);
 	return ERR_WRITING_FILE;
+close_failure:
+	SMSD_LogErrno(Config,
+			 "AddSentSMSInfo: Could not flush sent-info update; treating message as sent");
+#ifndef WIN32
+	if (tempDirFd >= 0) {
+		close(tempDirFd);
+	}
+	if (originalFd >= 0) {
+		close(originalFd);
+	}
+#endif
+	if (TempPath[0] != '\0') {
+		SMSD_Log(DEBUG_INFO, Config,
+			 "AddSentSMSInfo: Leaving temporary file after close failure: %s",
+			 TempPath);
+	}
+	free(GSMFile.Buffer);
+	return ERR_NONE;
 }
 
 GSM_Error SMSD_Check_Dir(GSM_SMSDConfig *Config, const char *path, const char *name)

--- a/tests/smsd-files-outbox.c
+++ b/tests/smsd-files-outbox.c
@@ -1,6 +1,8 @@
 #include <gammu.h>
 
 #include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,6 +10,7 @@
 #ifdef WIN32
 #include <io.h>
 #else
+#include <dirent.h>
 #include <unistd.h>
 #endif
 
@@ -15,6 +18,14 @@
 #include "../smsd/services/files.h"
 
 #define TEST_FILENAME_LENGTH 180
+
+#ifdef PATH_MAX
+#define TEST_FILES_PATH_MAX PATH_MAX
+#else
+#define TEST_FILES_PATH_MAX 4069
+#endif
+
+static const char sent_info_filename[] = "OUT12345.smsbackup";
 
 static char *CreateOutboxFile(const char *outbox_path, const char *filename)
 {
@@ -210,6 +221,462 @@ static int TestLongDestinationPath(GSM_StateMachine *state_machine,
 	return result;
 }
 
+static int IsTemporaryFilename(const char *filename)
+{
+	return filename[0] == '.' && strlen(filename) == sizeof(".XXXXXX") - 1;
+}
+
+static int HasTemporaryFile(const char *outbox_path)
+{
+#ifdef WIN32
+	struct _finddata_t entry;
+	intptr_t handle;
+	char *pattern;
+	size_t pattern_length;
+	int found = 0;
+
+	pattern_length = strlen(outbox_path) + sizeof(".*");
+	pattern = malloc(pattern_length);
+	if (pattern == NULL) {
+		fprintf(stderr, "Failed to allocate temporary-file pattern\n");
+		return 1;
+	}
+	snprintf(pattern, pattern_length, "%s.*", outbox_path);
+	handle = _findfirst(pattern, &entry);
+	free(pattern);
+	if (handle == -1) {
+		return 0;
+	}
+	do {
+		if (IsTemporaryFilename(entry.name)) {
+			found = 1;
+			break;
+		}
+	} while (_findnext(handle, &entry) == 0);
+	_findclose(handle);
+	return found;
+#else
+	DIR *directory;
+	struct dirent *entry;
+	int found = 0;
+
+	directory = opendir(outbox_path);
+	if (directory == NULL) {
+		fprintf(stderr, "Failed to open outbox directory\n");
+		return 1;
+	}
+	while ((entry = readdir(directory)) != NULL) {
+		if (IsTemporaryFilename(entry->d_name)) {
+			found = 1;
+			break;
+		}
+	}
+	closedir(directory);
+	return found;
+#endif
+}
+
+static int TestSentInfo(GSM_StateMachine *state_machine,
+			const char *outbox_path, gboolean read_only)
+{
+	static const char contents[] =
+		"[SMSBackup000]\n"
+		"MessageReference = 7\n"
+		"FirstPart = preserved\n"
+		"[SMSBackup001]\n"
+		"BeforeReference = preserved\n"
+		"MessageReference = 8\n"
+		"AfterReference = preserved\n";
+	static const char expected[] =
+		"[SMSBackup000]\n"
+		"MessageReference = 7\n"
+		"FirstPart = preserved\n"
+		"[SMSBackup001]\n"
+		"BeforeReference = preserved\n"
+		"MessageReference = 42\n"
+		"AfterReference = preserved\n";
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char *full_path;
+	char buffer[sizeof(expected) + 1];
+	size_t full_path_length;
+	size_t length;
+	FILE *file = NULL;
+	int fd;
+	int result = 0;
+#ifdef WIN32
+	BY_HANDLE_FILE_INFORMATION original_status;
+	BY_HANDLE_FILE_INFORMATION updated_status;
+#else
+	struct stat original_status;
+	struct stat updated_status;
+#endif
+
+	full_path_length = strlen(outbox_path) + strlen(sent_info_filename) + 1;
+	full_path = malloc(full_path_length);
+	if (full_path == NULL) {
+		fprintf(stderr, "Failed to allocate sent-info path\n");
+		return 1;
+	}
+	snprintf(full_path, full_path_length, "%s%s", outbox_path, sent_info_filename);
+
+	remove(full_path);
+#ifdef WIN32
+	{
+		HANDLE file_handle = CreateFileA(
+			full_path, GENERIC_WRITE, 0, NULL, CREATE_NEW,
+			read_only ? FILE_ATTRIBUTE_READONLY : FILE_ATTRIBUTE_NORMAL,
+			NULL);
+
+		if (file_handle == INVALID_HANDLE_VALUE) {
+			fprintf(stderr, "Failed to create sent-info file\n");
+			result = 1;
+			goto cleanup;
+		}
+		fd = _open_osfhandle((intptr_t)file_handle, _O_WRONLY | _O_BINARY);
+		if (fd < 0) {
+			CloseHandle(file_handle);
+			fprintf(stderr, "Failed to create sent-info descriptor\n");
+			result = 1;
+			goto cleanup;
+		}
+	}
+#else
+	fd = open(full_path, O_WRONLY | O_CREAT | O_EXCL, 0600);
+	if (fd < 0) {
+		fprintf(stderr, "Failed to create sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+#endif
+	file = fdopen(fd, "wb");
+	if (file == NULL) {
+#ifdef WIN32
+		_close(fd);
+#else
+		close(fd);
+#endif
+		fprintf(stderr, "Failed to open sent-info stream\n");
+		result = 1;
+		goto cleanup;
+	}
+	if (fwrite(contents, 1, strlen(contents), file) != strlen(contents)) {
+		fprintf(stderr, "Failed to create sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+#ifdef WIN32
+	if (!GetFileInformationByHandle((HANDLE)_get_osfhandle(fd), &original_status) ||
+	    (((original_status.dwFileAttributes & FILE_ATTRIBUTE_READONLY) != 0) !=
+	     read_only)) {
+		fprintf(stderr, "Sent-info file has unexpected attributes\n");
+		result = 1;
+		goto cleanup;
+	}
+#else
+	if ((read_only && fchmod(fd, 0400) != 0) ||
+	    fstat(fd, &original_status) != 0) {
+		fprintf(stderr, "Failed to prepare sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+#endif
+	if (fclose(file) != 0) {
+		file = NULL;
+		fprintf(stderr, "Failed to close sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+	file = NULL;
+
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
+	strcpy((char *)config.SMSID, sent_info_filename);
+	memset(&sms, 0, sizeof(sms));
+	sms.Number = 2;
+	GSM_SetDefaultSMSData(&sms.SMS[0]);
+	GSM_SetDefaultSMSData(&sms.SMS[1]);
+	EncodeUnicode(sms.SMS[0].Number, "12345", strlen("12345"));
+
+	error = SMSDFiles.AddSentSMSInfo(
+		&sms, &config, (char *)config.SMSID, 2, SMSD_SEND_OK, 42);
+	if (error != ERR_NONE) {
+		fprintf(stderr, "Failed to update %ssent-info file: %s\n",
+			read_only ? "non-writable " : "", GSM_ErrorString(error));
+		result = 1;
+		goto cleanup;
+	}
+
+	file = fopen(full_path, "rb");
+	if (file == NULL) {
+		fprintf(stderr, "Failed to read updated sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+	length = fread(buffer, 1, sizeof(buffer) - 1, file);
+	buffer[length] = '\0';
+
+#ifdef WIN32
+	if (!GetFileInformationByHandle(
+			(HANDLE)_get_osfhandle(fileno(file)), &updated_status) ||
+	    (updated_status.dwFileAttributes & FILE_ATTRIBUTE_READONLY) != 0) {
+		fprintf(stderr, "Sent-info update left the file read-only\n");
+		result = 1;
+		goto cleanup;
+	}
+	if (!read_only &&
+	    (updated_status.dwVolumeSerialNumber != original_status.dwVolumeSerialNumber ||
+	     updated_status.nFileIndexHigh != original_status.nFileIndexHigh ||
+	     updated_status.nFileIndexLow != original_status.nFileIndexLow)) {
+		fprintf(stderr, "Writable sent-info update replaced the file\n");
+		result = 1;
+		goto cleanup;
+	}
+#else
+	if (fstat(fileno(file), &updated_status) != 0 ||
+	    (updated_status.st_mode & 07777) != (original_status.st_mode & 07777) ||
+	    updated_status.st_uid != original_status.st_uid ||
+	    updated_status.st_gid != original_status.st_gid) {
+		fprintf(stderr, "Sent-info update did not preserve file permissions\n");
+		result = 1;
+		goto cleanup;
+	}
+	if (!read_only &&
+	    (updated_status.st_dev != original_status.st_dev ||
+	     updated_status.st_ino != original_status.st_ino)) {
+		fprintf(stderr, "Writable sent-info update replaced the file\n");
+		result = 1;
+		goto cleanup;
+	}
+#endif
+
+	if (fclose(file) != 0) {
+		file = NULL;
+		fprintf(stderr, "Failed to close updated sent-info file\n");
+		result = 1;
+		goto cleanup;
+	}
+	file = NULL;
+	if (strcmp(buffer, expected) != 0) {
+		fprintf(stderr, "Sent-info update changed unexpected content\n");
+		result = 1;
+		goto cleanup;
+	}
+#ifdef WIN32
+	if (read_only) {
+		error = SMSDFiles.MoveSMS(
+			&sms, &config, (char *)config.SMSID, FALSE, TRUE);
+		if (error != ERR_NONE ||
+		    GetFileAttributesA(full_path) != INVALID_FILE_ATTRIBUTES) {
+			fprintf(stderr,
+				"Failed to remove updated read-only outbox file\n");
+			result = 1;
+			goto cleanup;
+		}
+	}
+#endif
+	if (HasTemporaryFile(outbox_path)) {
+		fprintf(stderr, "Sent-info update left a temporary file\n");
+		result = 1;
+		goto cleanup;
+	}
+
+cleanup:
+	if (file != NULL) {
+		fclose(file);
+	}
+#ifdef WIN32
+	{
+		DWORD attributes = GetFileAttributesA(full_path);
+
+		if (attributes != INVALID_FILE_ATTRIBUTES) {
+			attributes &= ~FILE_ATTRIBUTE_READONLY;
+			SetFileAttributesA(
+				full_path, attributes == 0 ? FILE_ATTRIBUTE_NORMAL : attributes);
+		}
+	}
+#endif
+	remove(full_path);
+	free(full_path);
+	return result;
+}
+
+static int TestTemporaryFileIgnored(GSM_StateMachine *state_machine,
+				    const char *outbox_path)
+{
+	static const char filename[] = ".ABCDEF";
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+	char *full_path;
+	int result = 0;
+
+	full_path = CreateOutboxFile(outbox_path, filename);
+	if (full_path == NULL) {
+		return 1;
+	}
+	memset(&sms, 0, sizeof(sms));
+	memset(id, 0, sizeof(id));
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
+
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_EMPTY) {
+		fprintf(stderr, "Temporary outbox file returned %s\n",
+			GSM_ErrorString(error));
+		result = 1;
+	}
+
+	remove(full_path);
+	free(full_path);
+	return result;
+}
+
+#ifndef WIN32
+static int TestSymlinkIgnored(GSM_StateMachine *state_machine,
+			      const char *outbox_path)
+{
+	static const char target_filename[] = "source.smsbackup";
+	static const char symlink_filename[] = "OUT-symlink.smsbackup";
+	GSM_MultiSMSMessage sms;
+	GSM_SMSDConfig config;
+	GSM_Error error;
+	char id[GSM_MAX_FILENAME_LENGTH + 1];
+	char *target_path;
+	char *symlink_path;
+	size_t symlink_path_length;
+	int result = 0;
+
+	target_path = CreateOutboxFile(outbox_path, target_filename);
+	if (target_path == NULL) {
+		return 1;
+	}
+	symlink_path_length = strlen(outbox_path) + strlen(symlink_filename) + 1;
+	symlink_path = malloc(symlink_path_length);
+	if (symlink_path == NULL) {
+		remove(target_path);
+		free(target_path);
+		return 1;
+	}
+	snprintf(symlink_path, symlink_path_length, "%s%s",
+		 outbox_path, symlink_filename);
+	remove(symlink_path);
+	if (symlink(target_path, symlink_path) != 0) {
+		fprintf(stderr, "Failed to create outbox symlink\n");
+		result = 1;
+		goto cleanup;
+	}
+
+	memset(&sms, 0, sizeof(sms));
+	memset(id, 0, sizeof(id));
+	SetupConfig(&config, state_machine, outbox_path, outbox_path, outbox_path);
+	error = SMSDFiles.FindOutboxSMS(&sms, &config, id);
+	if (error != ERR_EMPTY) {
+		fprintf(stderr, "Symlink outbox file returned %s\n",
+			GSM_ErrorString(error));
+		result = 1;
+	}
+
+cleanup:
+	remove(symlink_path);
+	remove(target_path);
+	free(symlink_path);
+	free(target_path);
+	return result;
+}
+
+static void RemoveLongOutboxPath(char *path, size_t base_length)
+{
+	char *separator;
+	size_t length;
+
+	while ((length = strlen(path)) > base_length) {
+		if (path[length - 1] == '/') {
+			path[length - 1] = '\0';
+		}
+		rmdir(path);
+		separator = strrchr(path, '/');
+		if (separator == NULL) {
+			break;
+		}
+		separator[1] = '\0';
+	}
+}
+
+static char *CreateLongOutboxPath(const char *base_path)
+{
+	static const char directory_template[] = ".smsd-long-XXXXXX";
+	char *path;
+	size_t base_length = strlen(base_path);
+	size_t component_length;
+	size_t current_length;
+	size_t remaining;
+	size_t target_length;
+
+	target_length = TEST_FILES_PATH_MAX - strlen(sent_info_filename) - 1;
+	if (base_length + sizeof(directory_template) >= target_length) {
+		fprintf(stderr, "Test outbox path is too long\n");
+		return NULL;
+	}
+	path = malloc(target_length + 1);
+	if (path == NULL) {
+		fprintf(stderr, "Failed to allocate long outbox path\n");
+		return NULL;
+	}
+	snprintf(path, target_length + 1, "%s%s", base_path, directory_template);
+	if (mkdtemp(path) == NULL) {
+		fprintf(stderr, "Failed to create long outbox root\n");
+		free(path);
+		return NULL;
+	}
+	current_length = strlen(path);
+	path[current_length++] = '/';
+	path[current_length] = '\0';
+
+	while (current_length < target_length) {
+		remaining = target_length - current_length;
+		if (remaining < 2) {
+			fprintf(stderr, "Could not construct long outbox path\n");
+			RemoveLongOutboxPath(path, base_length);
+			free(path);
+			return NULL;
+		}
+		component_length = remaining > 201 ? 200 : remaining - 1;
+		if (remaining - component_length - 1 == 1) {
+			component_length--;
+		}
+		memset(path + current_length, 'd', component_length);
+		current_length += component_length;
+		path[current_length] = '\0';
+		if (mkdir(path, 0700) != 0) {
+			fprintf(stderr, "Failed to create long outbox directory\n");
+			RemoveLongOutboxPath(path, base_length);
+			free(path);
+			return NULL;
+		}
+		path[current_length++] = '/';
+		path[current_length] = '\0';
+	}
+	return path;
+}
+
+static int TestLongSentInfoPath(GSM_StateMachine *state_machine,
+				const char *outbox_path)
+{
+	char *long_outbox_path;
+	int result;
+
+	long_outbox_path = CreateLongOutboxPath(outbox_path);
+	if (long_outbox_path == NULL) {
+		return 1;
+	}
+	result = TestSentInfo(state_machine, long_outbox_path, TRUE);
+	RemoveLongOutboxPath(long_outbox_path, strlen(outbox_path));
+	free(long_outbox_path);
+	return result;
+}
+#endif
+
 int main(int argc, char **argv)
 {
 	static const char prefix[] = "OUTC20260729_120000_00_12345_";
@@ -251,6 +718,25 @@ int main(int argc, char **argv)
 	if (result == 0) {
 		result = TestLongDestinationPath(state_machine, argv[1], FALSE);
 	}
+	if (result == 0) {
+		result = TestTemporaryFileIgnored(state_machine, argv[1]);
+	}
+#ifndef WIN32
+	if (result == 0) {
+		result = TestSymlinkIgnored(state_machine, argv[1]);
+	}
+#endif
+	if (result == 0) {
+		result = TestSentInfo(state_machine, argv[1], FALSE);
+	}
+	if (result == 0) {
+		result = TestSentInfo(state_machine, argv[1], TRUE);
+	}
+#ifndef WIN32
+	if (result == 0) {
+		result = TestLongSentInfoPath(state_machine, argv[1]);
+	}
+#endif
 
 	GSM_FreeStateMachine(state_machine);
 	return result;


### PR DESCRIPTION
## Summary

- Update writable outbox files in place so their inode metadata is retained and no additional inode is required after an SMS has been sent.
- Open only the existing writable target, preventing a raced-away file from being recreated with default permissions.
- Fall back to a same-directory replacement for non-writable files, using a short private `.XXXXXX` directory that fits near the path limit and cannot be picked up by the `OUT*` scanner after a crash.
- Keep successful Windows replacements writable so the default sent-message cleanup can remove them.
- Attempt to retain POSIX owner, group, and mode on replacement files, reading both content and metadata through the already-open original file descriptor.
- Atomically claim and verify the POSIX outbox entry inside a trusted private directory, then hard-link the prepared inode back only while the destination remains unused, preserving messages submitted during the transition.
- Restore a claimed original when replacement installation fails and the outbox pathname is still unused, while closing all retained descriptors on every failure path.
- Install the replacement through its verified private directory descriptor so a submitter cannot swap the temporary pathname, and truncate writable originals only after stream allocation succeeds.
- Ignore non-regular POSIX outbox entries during discovery so a symlink is never transmitted and then rejected only during post-send finalization.
- Avoid unlinking a temporary pathname after failure because a message submitter could have replaced that directory entry; hidden leftovers remain ignored by the scanner.
- Treat delayed close or flush failures as nonfatal after successful transmission so the original message is moved instead of being sent again.
- Update the correct `MessageReference` entry for multipart messages and preserve all surrounding content.

## Root cause

Outbox files injected by another account can be readable by SMSD but not writable. The modem can successfully send the SMS before SMSD tries to persist its message reference. If that update fails, the original file remains queued and can be sent again.

Writable files now follow the historical in-place path. Only files that cannot be opened for writing use the replacement path, avoiding unnecessary metadata loss and failures when no temporary inode is available. The replacement path reads through the original file descriptor, atomically moves the current directory entry into its verified private directory, and checks that claimed inode before installation. It then uses a no-overwrite hard link for the prepared inode; if a producer has reused the pathname, that new message is preserved instead of being overwritten. Path buffers and the long-path regression use the platform `PATH_MAX`, including macOS's smaller limit.

## Compatibility

There are no public API or configuration changes. Writable files retain all inode metadata naturally. The non-writable replacement path intentionally handles portable basic metadata rather than requiring an ACL-specific dependency. On Windows, a cleared read-only attribute remains cleared after a successful replacement so `MoveSMS` can remove or move the sent entry. If replacement fails after claiming the original, SMSD restores it whenever the destination is still free; otherwise it leaves protected hidden entries for manual recovery instead of overwriting a new submission.

## Validation

- Built the `smsd-files-outbox` target.
- Passed `smsd-files-unicode-write` and `smsd-files-long-outbox-name`.
- Added coverage for writable and read-only files, Windows cleanup, symlink rejection, file identity, multipart content, orphaned temporary files, and near-limit paths.
- Passed the repository pre-commit hooks and `git diff --check`.

Closes #329
