### PR TITLE
ci(docs): reject unresolved Breathe functions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,13 @@ jobs:
     - name: Configure build
       run: ./configure
     - name: Build HTML docs
-      run: make manual-html
+      run: |
+        set -o pipefail
+        make manual-html 2>&1 | tee sphinx.log
+        if grep -Fq "Cannot find function" sphinx.log; then
+          echo "::error::Breathe could not resolve one or more documented functions"
+          exit 1
+        fi
     - name: Build PDF docs
       run: make manual-pdf
     - name: Collect


### PR DESCRIPTION
Missing Breathe function lookups leave the generated API documentation incomplete while the Sphinx build still succeeds. Detect these warnings explicitly so CI makes the regression visible.