### PR TITLE
ci(docs): fail builds on Sphinx warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,15 +22,9 @@ jobs:
     - name: Install Python deps
       run: uv pip install --system -r docs/manual/requirements.txt
     - name: Configure build
-      run: ./configure
+      run: cmake -S . -B build-configure -DSPHINX_BUILD_OPTIONS=-W
     - name: Build HTML docs
-      run: |
-        set -o pipefail
-        make manual-html 2>&1 | tee sphinx.log
-        if grep -Fq "Cannot find function" sphinx.log; then
-          echo "::error::Breathe could not resolve one or more documented functions"
-          exit 1
-        fi
+      run: make manual-html
     - name: Build PDF docs
       run: make manual-pdf
     - name: Collect

--- a/docs/manual/CMakeLists.txt
+++ b/docs/manual/CMakeLists.txt
@@ -24,13 +24,15 @@ find_program(SPHINX_BUILD_EXECUTABLE NAMES sphinx-build
 
 if (SPHINX_BUILD_EXECUTABLE)
     set (SPHINX_PAPER_SIZE "a4" CACHE STRING "Paper size for Sphinx LaTeX/PDF/PS output")
+    set (SPHINX_BUILD_OPTIONS "" CACHE STRING "Additional options passed to Sphinx")
+    separate_arguments(SPHINX_BUILD_OPTIONS)
     configure_file ("${CMAKE_CURRENT_SOURCE_DIR}/conf.py" "${CMAKE_CURRENT_BINARY_DIR}/conf.py" @ONLY)
     macro(sphinxdoc _format)
         add_custom_target (manual-${_format} ${SPHINX_BUILD_EXECUTABLE}
+                ${SPHINX_BUILD_OPTIONS}
                 -c ${CMAKE_CURRENT_BINARY_DIR}/
                 -n
                 -b ${_format}
-                -D latex_paper_size=${SPHINX_PAPER_SIZE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/
                 ${CMAKE_CURRENT_BINARY_DIR}/${_format}
             COMMENT "Generating Sphinx documentation (${_format})")

--- a/docs/manual/conf.py
+++ b/docs/manual/conf.py
@@ -19,7 +19,7 @@ import sphinx.domains.std
 
 
 def gammu_process_link(self, env, refnode, has_explicit_title, title, target):
-    program = env.temp_data.get("std:program")
+    program = env.ref_context.get("std:program")
     if not has_explicit_title:
         if " " in title and not (title.startswith(("/", "-"))):
             program, target = re.split(" (?=-|--|/)?", title, 1)
@@ -28,7 +28,7 @@ def gammu_process_link(self, env, refnode, has_explicit_title, title, target):
     elif " " in target:
         program, target = re.split(" (?=-|--|/)?", target, 1)
         program = sphinx.domains.std.ws_re.sub("-", program)
-    refnode["refprogram"] = program
+    refnode["std:program"] = program
     return title, target
 
 
@@ -53,7 +53,7 @@ sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 # ones.
 extensions = ["breathe", "configext", "sphinx.ext.graphviz", "sphinx.ext.intersphinx"]
 
-intersphinx_mapping = {"python": ("https://docs.python.org/3.9", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["@CMAKE_CURRENT_SOURCE_DIR@/.templates"]
@@ -88,7 +88,33 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
+
+# Breathe links types used inside documented declarations even when Doxygen
+# does not emit a corresponding target. These are C library types, private
+# structure tags, and public constants whose values are still shown in the
+# rendered declarations.
+nitpick_ignore_regex = [
+    ("c:identifier", r"(?:FILE|size_t|time_t)"),
+    (
+        "c:identifier",
+        (
+            r"(?:GSM_BACKUP_MAX_\w+|GSM_BITMAP_(?:SIZE|TEXT_LENGTH)|"
+            r"GSM_CALENDAR_ENTRIES|GSM_MAX\w+|"
+            r"GSM_PHONEBOOK_(?:ENTRIES|TEXT_LENGTH)|GSM_SECURITY_CODE_LEN|"
+            r"GSM_TODO_ENTRIES|SMSD_TEXT_LENGTH)"
+        ),
+    ),
+    ("c:identifier", r"(?:_GSM_Debug_Info|_GSM_SMSDConfig|_GSM_StateMachine)"),
+    (
+        "c:identifier",
+        (
+            r"(?:GSM_Phone_RequestID|GSM_Protocol_Message|"
+            r"GSM_SMSDSendingError|GSM_StringArray)"
+        ),
+    ),
+    ("std:ref", r"(?:bug|todo)_1_(?:bug|todo)\d+"),
+]
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -230,7 +256,7 @@ htmlhelp_basename = "gammudoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #    'papersize': 'a4',
+    "papersize": "@SPHINX_PAPER_SIZE@paper",
     # The font size ('10pt', '11pt' or '12pt').
     #'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.

--- a/docs/manual/configext.py
+++ b/docs/manual/configext.py
@@ -34,7 +34,7 @@ class ConfigOption(ObjectDescription):
                 indextype = "single"
                 indexentry = self.indextemplate % (name,)
             self.indexnode["entries"].append(
-                (indextype, indexentry, targetname, targetname),
+                (indextype, indexentry, targetname, targetname, None),
             )
         self.env.domaindata["config"]["objects"][self.objtype, name] = (
             self.env.docname,
@@ -52,8 +52,8 @@ class ConfigSectionXRefRole(XRefRole):
         tgtid = "index-{}".format(env.new_serialno("index"))
         indexnode = addnodes.index()
         indexnode["entries"] = [
-            ("single", varname, tgtid, varname),
-            ("single", f"configuration section; {varname}", tgtid, varname),
+            ("single", varname, tgtid, varname, None),
+            ("single", f"configuration section; {varname}", tgtid, varname, None),
         ]
         targetnode = nodes.target("", "", ids=[tgtid])
         document.note_explicit_target(targetnode)
@@ -87,7 +87,7 @@ class ConfigSection(ObjectDescription):
                 indextype = "single"
                 indexentry = self.indextemplate % (name,)
             self.indexnode["entries"].append(
-                (indextype, indexentry, targetname, targetname),
+                (indextype, indexentry, targetname, targetname, None),
             )
         self.env.domaindata["config"]["objects"][self.objtype, name] = (
             self.env.docname,

--- a/docs/manual/contents.rst
+++ b/docs/manual/contents.rst
@@ -1,5 +1,3 @@
-.. _contents:
-
 Gammu Documentation Contents
 ----------------------------
 

--- a/docs/manual/faq/smsd.rst
+++ b/docs/manual/faq/smsd.rst
@@ -46,7 +46,7 @@ There can be various reasons why the script you've supplied as
 in the debug log (see :ref:`reporting-bugs-smsd`). For example it can look like
 following:
 
-.. code-block:: log
+.. code-block:: text
 
     gammu-smsd[9886]: Starting run on receive: ../received.sh
     gammu-smsd[9875]: Process failed with exit status 2

--- a/docs/manual/gammu/index.rst
+++ b/docs/manual/gammu/index.rst
@@ -842,11 +842,11 @@ level and Gammu does not use that.
 
     Delete folder with given ID.
 
-.. option:: getfilefolder fileID, fileID, ...
+.. option:: getfilefolder fileID [fileID ...]
 
     Retrieve files or all files from folder with given IDs from a phone filesystem.
 
-.. option:: getfiles fileID, fileID, ...
+.. option:: getfiles fileID [fileID ...]
 
     Retrieve files with given IDs from a phone filesystem.
 

--- a/docs/manual/internal/new-phone.rst
+++ b/docs/manual/internal/new-phone.rst
@@ -13,7 +13,7 @@ only need to hook new code into right places.
 
 The main code for AT driver is in :file:`libgammu/phone/at/atgen.c`. At the
 bottom of the file, you can find two arrays, one defining driver interface
-(:c:type:`GSM_Phone_Functions`) and second one defining callbacks (see
+(:c:type:`!GSM_Phone_Functions`) and second one defining callbacks (see
 :ref:`reply-functions` for more detailed description. You will definitely need
 to define callbacks for newly introduced commands, but the interface for
 desired functionality might already exist.
@@ -72,8 +72,8 @@ some commands.
 Invoking AT command
 +++++++++++++++++++
 
-The AT commands are invoked using :c:func:`GSM_WaitFor`, or a wrapper
-:c:func:`ATGEN_WaitForAutoLen`, where you don't have to specify length for
+The AT commands are invoked using :c:func:`!GSM_WaitFor`, or a wrapper
+:c:func:`!ATGEN_WaitForAutoLen`, where you don't have to specify length for
 text commands and automatically sets error variable.
 
 Generally you need to construct buffer and then invoke it. For some simple
@@ -98,9 +98,9 @@ for most data types ``s->Phone.Data`` does contain the pointer to do that.
 Parsing reply
 +++++++++++++
 
-For parsing reply, you should use :c:func:`ATGEN_ParseReply`, which should
+For parsing reply, you should use :c:func:`!ATGEN_ParseReply`, which should
 be able to handle all encoding and parsing magic. You can grab lines from the
-reply using :c:func:`GetLineString`.
+reply using :c:func:`!GetLineString`.
 
 The reply function needs to be hooked to the reply functions array, so that it
 is invoked when reply is received from the phone.
@@ -165,9 +165,9 @@ function would look like:
 
 As you can see, all reply function first need to handle which error code did
 they receive and return appropriate error if needed. Functions
-:c:func:`ATGEN_HandleCMSError` and :c:func:`ATGEN_HandleCMEError` simplify
+:c:func:`!ATGEN_HandleCMSError` and :c:func:`!ATGEN_HandleCMEError` simplify
 this, but you might need to customize it by handling some error codes manually
 (eg. when phone returns error on empty location).
 
-The rest of the function is just call to :c:func:`ATGEN_ParseReply` and
+The rest of the function is just call to :c:func:`!ATGEN_ParseReply` and
 processing parsed data.

--- a/docs/manual/internal/reply.rst
+++ b/docs/manual/internal/reply.rst
@@ -30,7 +30,7 @@ getting sms status.
 
     .. c:member:: const GSM_Phone_RequestID	requestID;
 
-       Match for request ID. this is filled in when calling :c:func:`GSM_WaitFor`.
+       Match for request ID. this is filled in when calling :c:func:`!GSM_WaitFor`.
 
 There are three types of answer matching:
 

--- a/docs/manual/python/gammu.rst
+++ b/docs/manual/python/gammu.rst
@@ -886,7 +886,7 @@ This module wraps all python-gammu functionality.
       Sets state machine debug file.
 
       :param File: File where to write debug stuff (as configured by :meth:`SetDebugLevel`). Can be either None for no file, Python file object or filename.
-      :type File: mixed
+      :type File: object
       :param Global: Whether to use global debug structure (overrides File)
       :type Global: bool
       :return: None
@@ -956,7 +956,7 @@ This module wraps all python-gammu functionality.
       The callback function needs to accept three parameters: StateMachine object, event type and it's data in dictionary.
 
       :param Callback: callback function or None for disabling
-      :type Callback: function
+      :type Callback: collections.abc.Callable
       :return: None
       :rtype: None
 
@@ -1118,7 +1118,7 @@ Debugging configuration
     Sets global debug file.
 
     :param File: File where to write debug stuff (as configured by :meth:`SetDebugLevel`). Can be either None for no file, Python file object or filename.
-    :type File: mixed
+    :type File: object
     :return: None
     :rtype: None
 

--- a/docs/manual/python/objects.rst
+++ b/docs/manual/python/objects.rst
@@ -19,68 +19,68 @@ bytes of data). You can construct it from :ref:`sms_info_obj` using
 
 Message dictionary can consist of following fields:
 
-.. attribute:: SMSC
+.. describe:: SMSC
 
    SMSC information, see :ref:`smsc_obj`.
 
-.. attribute:: Number
+.. describe:: Number
 
    Recipient number, needs to be set for sending.
 
-.. attribute:: Name
+.. describe:: Name
 
    Name of the message, does not make any effect on sending, some phones might
    store it.
 
-.. attribute:: UDH
+.. describe:: UDH
 
    User defined headers for SMS, see :ref:`udh_obj`.
 
-.. attribute:: Text
+.. describe:: Text
 
    Message text
 
-.. attribute:: Folder
+.. describe:: Folder
 
    Folder where the message is stored
 
-.. attribute:: Location
+.. describe:: Location
 
    Location where the message is stored
 
-.. attribute:: InboxFolder
+.. describe:: InboxFolder
 
    Indication whether folder is an inbox
 
-.. attribute:: DeliveryStatus
+.. describe:: DeliveryStatus
 
    Message delivery status, used only for received messages
 
-.. attribute:: ReplyViaSameSMSC
+.. describe:: ReplyViaSameSMSC
 
    Flag indicating whether reply using same SMSC is requested
 
-.. attribute:: Class
+.. describe:: Class
 
    Message class
 
-.. attribute:: MessageReference
+.. describe:: MessageReference
 
    Message reference number, used mostly to identify delivery reports
 
-.. attribute:: ReplaceMessage
+.. describe:: ReplaceMessage
 
    Id of message which this message is supposed to replace
 
-.. attribute:: RejectDuplicates
+.. describe:: RejectDuplicates
 
    Whether to reject duplicates
 
-.. attribute:: Memory
+.. describe:: Memory
 
    Memory where the message is stored
 
-.. attribute:: Type
+.. describe:: Type
 
    Message type, one of:
 
@@ -89,7 +89,7 @@ Message dictionary can consist of following fields:
 * ``Status_Report`` - when creating new message this will create submit message
   with request for delivery report
 
-.. attribute:: Coding
+.. describe:: Coding
 
    Message encoding, one of:
 
@@ -101,17 +101,17 @@ Message dictionary can consist of following fields:
 * ``Default_Compression`` - not supported by Gammu and most phones
 * ``8bit`` - for binary messages
 
-.. attribute:: DateTime
+.. describe:: DateTime
 
    Timestamp when the message was received or sent.
 
    Please note that most phones do no record timestamp of sent messages.
 
-.. attribute:: SMSCDateTime
+.. describe:: SMSCDateTime
 
    Timestamp when the message was at SMSC.
 
-.. attribute:: State
+.. describe:: State
 
    Message state, one of:
 
@@ -145,23 +145,23 @@ UDH Object
 
 UDH dictionary can consist of following fields:
 
-.. attribute:: ID8bit
+.. describe:: ID8bit
 
    8-bit ID of the message, not required
 
-.. attribute:: ID16bit
+.. describe:: ID16bit
 
    16-bit ID of the message, not required
 
-.. attribute:: PartNumber
+.. describe:: PartNumber
 
    Number of current part
 
-.. attribute:: AllParts
+.. describe:: AllParts
 
    Count of all message parts
 
-.. attribute:: Type
+.. describe:: Type
 
    UDH type, one of predefined strings:
 
@@ -186,7 +186,7 @@ UDH dictionary can consist of following fields:
 * ``NokiaPhonebookLong``
 * ``UserUDH``
 
-.. attribute:: Text
+.. describe:: Text
 
    UDH content
 
@@ -208,23 +208,23 @@ SMSC Object
 
 SMSC dictionary can consist of following fields:
 
-.. attribute:: Location
+.. describe:: Location
 
    Location where the SMSC is stored
 
-.. attribute:: Number
+.. describe:: Number
 
    SMSC number
 
-.. attribute:: Name
+.. describe:: Name
 
    Name of the SMSC configuration
 
-.. attribute:: DefaultNumber
+.. describe:: DefaultNumber
 
    Default recipient number, ignored on most phones
 
-.. attribute:: Format
+.. describe:: Format
 
    Default message format, one of:
 
@@ -233,7 +233,7 @@ SMSC dictionary can consist of following fields:
 * ``Fax``
 * ``Email``
 
-.. attribute:: Validity
+.. describe:: Validity
 
    Default message validity as a string
 
@@ -260,23 +260,23 @@ SMS Info Object
 
 Message info dictionary can consist of following fields:
 
-.. attribute:: Unicode
+.. describe:: Unicode
 
    Whether to use Unicode for the message.
 
-.. attribute:: ReplaceMessage
+.. describe:: ReplaceMessage
 
    Id of message which this message is supposed to replace
 
-.. attribute:: Unknown
+.. describe:: Unknown
 
    Boolean flag indicating there was some part which Gammu could not decode.
 
-.. attribute:: Class
+.. describe:: Class
 
    Message class
 
-.. attribute:: Entries
+.. describe:: Entries
 
    Actual message data, see :ref:`sms_info_part_obj`.
 
@@ -301,7 +301,7 @@ SMS Info Part Object
 
 Message component can consist of following fields:
 
-.. attribute:: ID
+.. describe:: ID
 
    Identification of the part type:
 
@@ -353,87 +353,87 @@ Message component can consist of following fields:
 * ``AlcatelSMSTemplateName``
 * ``SiemensFile`` - Siemens OTA
 
-.. attribute:: Left
+.. describe:: Left
 
    Text formatting
 
-.. attribute:: Right
+.. describe:: Right
 
    Text formatting
 
-.. attribute:: Center
+.. describe:: Center
 
    Text formatting
 
-.. attribute:: Large
+.. describe:: Large
 
    Text formatting
 
-.. attribute:: Small
+.. describe:: Small
 
    Text formatting
 
-.. attribute:: Bold
+.. describe:: Bold
 
    Text formatting
 
-.. attribute:: Italic
+.. describe:: Italic
 
    Text formatting
 
-.. attribute:: Underlined
+.. describe:: Underlined
 
    Text formatting
 
-.. attribute:: Strikethrough
+.. describe:: Strikethrough
 
    Text formatting
 
-.. attribute:: Protected
+.. describe:: Protected
 
    Whether message part should be protected (DRM)
 
-.. attribute:: Number
+.. describe:: Number
 
    Number to encode in message.
 
-.. attribute:: Ringtone
+.. describe:: Ringtone
 
    Ringtone to encode in message.
 
-.. attribute:: Bitmap
+.. describe:: Bitmap
 
    Bitmap to encode in message.
 
-.. attribute:: Bookmark
+.. describe:: Bookmark
 
    Bookmark to encode in message.
 
-.. attribute:: Settings
+.. describe:: Settings
 
    Settings to encode in message.
 
-.. attribute:: MMSIndicator
+.. describe:: MMSIndicator
 
    MMS indication to encode in message.
 
-.. attribute:: Phonebook
+.. describe:: Phonebook
 
    Phonebook entry to encode in message, see :ref:`pbk_obj`.
 
-.. attribute:: Calendar
+.. describe:: Calendar
 
    Calendar entry to encode in message, see :ref:`cal_obj`.
 
-.. attribute:: ToDo
+.. describe:: ToDo
 
    Todo entry to encode in message, see :ref:`todo_obj`.
 
-.. attribute:: File
+.. describe:: File
 
    File to encode in message, see :ref:`file_obj`.
 
-.. attribute:: Buffer
+.. describe:: Buffer
 
    String to encode in message.
 
@@ -444,11 +444,11 @@ Todo Object
 
 Todo entry is a dictionary consisting of following fields:
 
-.. attribute:: Location
+.. describe:: Location
 
    Location where the entry is stored
 
-.. attribute:: Type
+.. describe:: Type
 
    Type of entry, one of:
 
@@ -481,7 +481,7 @@ Todo entry is a dictionary consisting of following fields:
 * ``ALARM`` - Alarm
 * ``DAILY_ALARM`` - Alarm repeating each day.
 
-.. attribute:: Priority
+.. describe:: Priority
 
    Entry priority, one of:
 
@@ -490,7 +490,7 @@ Todo entry is a dictionary consisting of following fields:
 * ``Low``
 * ``None``
 
-.. attribute:: Entries
+.. describe:: Entries
 
    Actual entries, see :ref:`todo_entry_obj`
 
@@ -514,7 +514,7 @@ Example:
 Todo Entries Object
 -------------------
 
-.. attribute:: Type
+.. describe:: Type
 
    Type of entry, one of:
 
@@ -533,7 +533,7 @@ Todo Entries Object
 * ``LAST_MODIFIED`` - Date and time of last modification (Date).
 * ``START_DATETIME`` - Start date (Date).
 
-.. attribute:: Value
+.. describe:: Value
 
    Actual value, corresponding type to Type field.
 
@@ -544,11 +544,11 @@ Calendar Object
 
 Calendar entry is a dictionary consisting of following fields:
 
-.. attribute:: Location
+.. describe:: Location
 
    Location where the entry is stored
 
-.. attribute:: Type
+.. describe:: Type
 
    Type of entry, one of:
 
@@ -581,7 +581,7 @@ Calendar entry is a dictionary consisting of following fields:
 * ``ALARM`` - Alarm
 * ``DAILY_ALARM`` - Alarm repeating each day.
 
-.. attribute:: Entries
+.. describe:: Entries
 
    Actual entries, see :ref:`cal_entry_obj`
 
@@ -607,7 +607,7 @@ Example:
 Calendar Entries Object
 -----------------------
 
-.. attribute:: Type
+.. describe:: Type
 
    Type of entry, one of:
 
@@ -633,7 +633,7 @@ Calendar Entries Object
 * ``LUID`` - IrMC LUID which can be used for synchronisation.
 * ``LAST_MODIFIED`` - Date and time of last modification.
 
-.. attribute:: Value
+.. describe:: Value
 
    Actual value, corresponding type to Type field.
 
@@ -644,15 +644,15 @@ Phonebook Object
 
 Phonebook entry is a dictionary consisting of following fields:
 
-.. attribute:: Location
+.. describe:: Location
 
    Location where the entry is stored
 
-.. attribute:: MemoryType
+.. describe:: MemoryType
 
    Memory where the message is stored
 
-.. attribute:: Entries
+.. describe:: Entries
 
    Actual entries, see :ref:`pbk_entry_obj`
 
@@ -674,7 +674,7 @@ Example:
 Phonebook Entries Object
 ------------------------
 
-.. attribute:: Type
+.. describe:: Type
 
     Type of entry, one of:
 
@@ -728,7 +728,7 @@ Phonebook Entries Object
     * ``NamePrefix`` - Name prefix (Text)
     * ``NameSuffix`` - Name suffix (Text)
 
-.. attribute:: Location
+.. describe:: Location
 
     Location for the field:
 
@@ -736,11 +736,11 @@ Phonebook Entries Object
     * ``Home`` - home
     * ``Work`` - work
 
-.. attribute:: Value
+.. describe:: Value
 
    Actual value, corresponding type to Type field.
 
-.. attribute:: PictureType
+.. describe:: PictureType
 
    Type of picture which is stored in Value field (only for Picture fields).
 
@@ -751,23 +751,23 @@ File Object
 
 File is a dictionary consisting of following fields:
 
-.. attribute:: Used
+.. describe:: Used
 
    Number of bytes used by this file.
 
-.. attribute:: Name
+.. describe:: Name
 
    File name.
 
-.. attribute:: Folder
+.. describe:: Folder
 
    Boolean value indicating whether this is a folder.
 
-.. attribute:: Level
+.. describe:: Level
 
    Depth of file on the filesystem.
 
-.. attribute:: Type
+.. describe:: Type
 
    File type, one of:
 
@@ -784,39 +784,39 @@ File is a dictionary consisting of following fields:
 * ``Sound_MIDI``
 * ``MMS``
 
-.. attribute:: ID_FullName
+.. describe:: ID_FullName
 
    Full file name including path.
 
-.. attribute:: Buffer
+.. describe:: Buffer
 
    Content of the file.
 
-.. attribute:: Modified
+.. describe:: Modified
 
    Timestamp of last change
 
-.. attribute:: Protected
+.. describe:: Protected
 
    Boolean value indicating whether file is protected (DRM).
 
-.. attribute:: ReadOnly
+.. describe:: ReadOnly
 
    Boolean value indicating whether file is read only.
 
-.. attribute:: Hidden
+.. describe:: Hidden
 
    Boolean value indicating whether file is hidden.
 
-.. attribute:: System
+.. describe:: System
 
    Boolean value indicating whether file is system.
 
-.. attribute:: Pos
+.. describe:: Pos
 
    Current position of file upload
 
-.. attribute:: Finished
+.. describe:: Finished
 
    Boolean value indicating completed file transfer.
 
@@ -868,18 +868,18 @@ The call type for diverts can have one of following values:
 Call Divert Objects
 -------------------
 
-.. attribute:: DivertType
+.. describe:: DivertType
 
     When to do the divert, see :ref:`divert-type`.
 
-.. attribute:: CallType
+.. describe:: CallType
 
     What call types to divert, see :ref:`divert-call`.
 
-.. attribute:: Number
+.. describe:: Number
 
     Phone number where to divert.
 
-.. attribute:: Timeout
+.. describe:: Timeout
 
     Timeout after which the divert will happen.

--- a/docs/manual/python/smsd.rst
+++ b/docs/manual/python/smsd.rst
@@ -18,7 +18,7 @@
     For more infos look into :ref:`Gammu SMSD Overview <gammu-smsd-overview>`.
 
     :param Config: Path to SMSD configuration file.
-    :type Config: string
+    :type Config: str
 
     .. method:: MainLoop(MaxFailures)
 
@@ -88,4 +88,4 @@
         :param Message: Message to inject (can be multipart)
         :type Message: list of :ref:`sms_obj`
         :return: ID of inserted message
-        :rtype: string
+        :rtype: str

--- a/docs/manual/python/worker.rst
+++ b/docs/manual/python/worker.rst
@@ -95,7 +95,7 @@ which are used by this class.
       Configures gammu instance according to config.
 
       :param config: Gammu configuration, same as :meth:`gammu.StateMachine.SetConfig` accepts.
-      :type config: hash
+      :type config: dict
 
 
    .. method:: GammuWorker.enqueue(command, params=None, commands=None)
@@ -104,11 +104,11 @@ which are used by this class.
       Enqueues command or task.
 
       :param command: Command(s) to execute. Each command is tuple containing function name and it's parameters.
-      :type command: tuple of list of tuples
+      :type command: tuple | list[tuple]
       :param params: Parameters to command.
-      :type params: tuple or string
+      :type params: tuple | str
       :param commands: List of commands to execute. When this is not none, params are ignored and command is taken as task name.
-      :type commands: list of tuples or strings
+      :type commands: list[tuple | str]
 
 
    .. method:: GammuWorker.enqueue_command(command, params)
@@ -117,9 +117,9 @@ which are used by this class.
       Enqueues command.
 
       :param command: Command(s) to execute. Each command is tuple containing function name and it's parameters.
-      :type command: tuple of list of tuples
+      :type command: tuple | list[tuple]
       :param params: Parameters to command.
-      :type params: tuple or string
+      :type params: tuple | str
 
 
    .. method:: GammuWorker.enqueue_task(command, commands)
@@ -128,9 +128,9 @@ which are used by this class.
       Enqueues task.
 
       :param command: Command(s) to execute. Each command is tuple containing function name and it's parameters.
-      :type command: tuple of list of tuples
+      :type command: tuple | list[tuple]
       :param commands: List of commands to execute.
-      :type commands: list of tuples or strings
+      :type commands: list[tuple | str]
 
 
    .. method:: GammuWorker.initiate()
@@ -157,4 +157,4 @@ which are used by this class.
    Checks whether command is valid.
 
    :param command: Name of command.
-   :type command: string
+   :type command: str

--- a/docs/manual/smsd/code.rst
+++ b/docs/manual/smsd/code.rst
@@ -18,28 +18,30 @@ Backend interface
 Each backend service needs to support several operations, which are exported
 in ``GSM_SMSDService`` structure:
 
-.. c:function:: GSM_Error	GSM_SMSDService::Init 	      (GSM_SMSDConfig *Config)
+.. c:namespace-push:: GSM_SMSDService
+
+.. c:member:: GSM_Error (*Init)(GSM_SMSDConfig *Config)
 
     Initializes internal state, connect to backend storage.
 
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::Free 	      (GSM_SMSDConfig *Config)
+.. c:member:: GSM_Error (*Free)(GSM_SMSDConfig *Config)
 
     Freeing internal data, disconnect from backend storage.
 
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::InitAfterConnect   (GSM_SMSDConfig *Config)
+.. c:member:: GSM_Error (*InitAfterConnect)(GSM_SMSDConfig *Config)
 
     Optional hook called after SMSD is connected to phone, can be used for storing information about phone in backend.
 
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::SaveInboxSMS       (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs)
+.. c:member:: GSM_Error (*SaveInboxSMS)(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, GSM_StringArray *Locations, GSM_StringArray *SentIDs)
 
     Saves message into inbox.
 
@@ -50,7 +52,7 @@ in ``GSM_SMSDService`` structure:
         delivery reports.
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::FindOutboxSMS      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID)
+.. c:member:: GSM_Error (*FindOutboxSMS)(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID)
 
     Finds message in outbox suitable for sending.
 
@@ -62,7 +64,7 @@ in ``GSM_SMSDService`` structure:
         this check.
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::MoveSMS  	      (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, gboolean alwaysDelete, gboolean sent)
+.. c:member:: GSM_Error (*MoveSMS)(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, gboolean alwaysDelete, gboolean sent)
 
     Moves sent message from outbox to sent items.
 
@@ -73,7 +75,7 @@ in ``GSM_SMSDService`` structure:
     :param sent: Whether message was sent (``TRUE``) or there was a failure (``FALSE``).
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::CreateOutboxSMS    (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *NewID)
+.. c:member:: GSM_Error (*CreateOutboxSMS)(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *NewID)
 
     Saves message into outbox queue.
 
@@ -82,7 +84,7 @@ in ``GSM_SMSDService`` structure:
     :param NewID: ID of created message will be stored here.
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::AddSentSMSInfo     (GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, int Part, GSM_SMSDSendingError err, int TPMR)
+.. c:member:: GSM_Error (*AddSentSMSInfo)(GSM_MultiSMSMessage *sms, GSM_SMSDConfig *Config, char *ID, int Part, GSM_SMSDSendingError err, int TPMR)
 
     Logs information about sent message (eg. delivery report).
 
@@ -94,7 +96,7 @@ in ``GSM_SMSDService`` structure:
     :param TPMR: Message reference if available (:term:`TPMR`).
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::RefreshSendStatus  (GSM_SMSDConfig *Config, char *ID)
+.. c:member:: GSM_Error (*RefreshSendStatus)(GSM_SMSDConfig *Config, char *ID)
 
     Updates sending status in service backend.
 
@@ -102,19 +104,21 @@ in ``GSM_SMSDService`` structure:
     :param ID: Identification of message to be marked.
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::RefreshPhoneStatus (GSM_SMSDConfig *Config)
+.. c:member:: GSM_Error (*RefreshPhoneStatus)(GSM_SMSDConfig *Config)
 
     Updates information about phone in database (network status, battery, etc.).
 
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
 
-.. c:function:: GSM_Error	GSM_SMSDService::ReadConfiguration (GSM_SMSDConfig *Config)
+.. c:member:: GSM_Error (*ReadConfiguration)(GSM_SMSDConfig *Config)
 
     Reads configuration specific for this backend.
 
     :param Config: Pointer to SMSD configuration data
     :return: Error code.
+
+.. c:namespace-pop::
 
 Message ID
 ++++++++++
@@ -125,24 +129,24 @@ just by it's internal identification instead of handling message data from
 :c:type:`GSM_MultiSMSMessage`.
 
 If the backend does not use any IDs internally, it really does not have to
-provide them, with only exception of :c:func:`GSM_SMSDService::FindOutboxSMS`,
+provide them, with only exception of :c:member:`GSM_SMSDService.FindOutboxSMS`,
 where ID is used for detection of repeated sending of same message.
 
 The lifetime of ID for sent message:
 
-    * :c:func:`GSM_SMSDService::CreateOutboxSMS` or direct manipulation
+    * :c:member:`GSM_SMSDService.CreateOutboxSMS` or direct manipulation
       with backend storage creates new ID
-    * :c:func:`GSM_SMSDService::FindOutboxSMS` returns ID of message to
+    * :c:member:`GSM_SMSDService.FindOutboxSMS` returns ID of message to
       process
-    * :c:func:`GSM_SMSDService::AddSentSMSInfo` and
-      :c:func:`GSM_SMSDService::RefreshSendStatus` are then notified using
+    * :c:member:`GSM_SMSDService.AddSentSMSInfo` and
+      :c:member:`GSM_SMSDService.RefreshSendStatus` are then notified using
       this ID about sending of the message
-    * :c:func:`GSM_SMSDService::MoveSMS` then moves the message based on
+    * :c:member:`GSM_SMSDService.MoveSMS` then moves the message based on
       ID to sent items
 
 The lifetime of ID for incoming messages:
 
-    * :c:func:`GSM_SMSDService::SaveInboxSMS` generates the message
+    * :c:member:`GSM_SMSDService.SaveInboxSMS` generates the message
     * :ref:`gammu-smsd-run` uses this ID
 
 Message Sending Workflow

--- a/docs/manual/smsd/pgsql.rst
+++ b/docs/manual/smsd/pgsql.rst
@@ -41,7 +41,7 @@ Creating tables for PostgreSQL
 SQL script for creating tables in PostgreSQL database:
 
 .. literalinclude:: ../../sql/pgsql.sql
-   :language: sql
+   :language: postgresql
 
 .. note::
 


### PR DESCRIPTION
Treating warnings as errors keeps broken references and invalid markup out of the published documentation.