### PR TITLE
at: accept SMS prompt sent as a bare ">" without trailing space

### DIFF
--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -1549,7 +1549,7 @@ GSM_Error ATGEN_DispatchMessage(GSM_StateMachine *s)
 	if (!strncmp(line,"+CPIN:", 6) && s->Protocol.Data.AT.CPINNoOK) {
 		Priv->ReplyState = AT_Reply_OK;
 	}
-	if (!strcmp(line,"> ")) {
+	if (!strcmp(line,"> ") || !strcmp(line,">")) {
 		Priv->ReplyState = AT_Reply_SMSEdit;
 	}
 	if (!strcmp(line,"CONNECT")) {

--- a/libgammu/phone/at/atgen.c
+++ b/libgammu/phone/at/atgen.c
@@ -1549,7 +1549,7 @@ GSM_Error ATGEN_DispatchMessage(GSM_StateMachine *s)
 	if (!strncmp(line,"+CPIN:", 6) && s->Protocol.Data.AT.CPINNoOK) {
 		Priv->ReplyState = AT_Reply_OK;
 	}
-	if (!strcmp(line,"> ") || !strcmp(line,">")) {
+	if (!strcmp(line, AT_SMS_PROMPT_PADDED) || !strcmp(line, AT_SMS_PROMPT_BARE)) {
 		Priv->ReplyState = AT_Reply_SMSEdit;
 	}
 	if (!strcmp(line,"CONNECT")) {

--- a/libgammu/protocol/at/at.c
+++ b/libgammu/protocol/at/at.c
@@ -189,6 +189,17 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 
 		/* Process line after \r\n */
 		if (d->Msg.Length > 0 && rx_char == 10 && d->Msg.Buffer[d->Msg.Length - 2] == 13) {
+			/* Some modems (eg. SIMCom SIM7670G) emit the SMS prompt as a bare
+			 * ">" terminated by CRLF instead of "> ", so the EditMode check
+			 * in the default branch never matches and GSM_WaitFor blocks. */
+			if (d->EditMode && d->LineStart >= 0 &&
+					d->LineEnd == d->LineStart + 1 &&
+					d->Msg.Buffer[d->LineStart] == '>') {
+				s->Phone.Data.RequestMsg	= &d->Msg;
+				s->Phone.Data.DispatchError	= s->Phone.Functions->DispatchMessage(s);
+				break;
+			}
+
 			/* Process standard responses */
 			for (i = 0; StatusStrings[i] != NULL; i++) {
 				if (strncmp(StatusStrings[i],

--- a/libgammu/protocol/at/at.c
+++ b/libgammu/protocol/at/at.c
@@ -193,9 +193,10 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 			 * ">" terminated by CRLF instead of "> ", so the EditMode check
 			 * in the default branch never matches and GSM_WaitFor blocks. */
 			if (d->EditMode && d->LineStart < d->Msg.Length &&
-					d->LineEnd - d->LineStart == strlen(AT_SMS_PROMPT_BARE) &&
+					d->LineEnd > d->LineStart &&
+					d->LineEnd - d->LineStart == sizeof(AT_SMS_PROMPT_BARE) - 1 &&
 					strncmp(d->Msg.Buffer + d->LineStart, AT_SMS_PROMPT_BARE,
-						strlen(AT_SMS_PROMPT_BARE)) == 0) {
+						sizeof(AT_SMS_PROMPT_BARE) - 1) == 0) {
 				s->Phone.Data.RequestMsg	= &d->Msg;
 				s->Phone.Data.DispatchError	= s->Phone.Functions->DispatchMessage(s);
 				break;

--- a/libgammu/protocol/at/at.c
+++ b/libgammu/protocol/at/at.c
@@ -192,9 +192,10 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 			/* Some modems (eg. SIMCom SIM7670G) emit the SMS prompt as a bare
 			 * ">" terminated by CRLF instead of "> ", so the EditMode check
 			 * in the default branch never matches and GSM_WaitFor blocks. */
-			if (d->EditMode && d->LineStart >= 0 &&
-					d->LineEnd == d->LineStart + 1 &&
-					d->Msg.Buffer[d->LineStart] == '>') {
+			if (d->EditMode && d->LineStart < d->Msg.Length &&
+					d->LineEnd - d->LineStart == strlen(AT_SMS_PROMPT_BARE) &&
+					strncmp(d->Msg.Buffer + d->LineStart, AT_SMS_PROMPT_BARE,
+						strlen(AT_SMS_PROMPT_BARE)) == 0) {
 				s->Phone.Data.RequestMsg	= &d->Msg;
 				s->Phone.Data.DispatchError	= s->Phone.Functions->DispatchMessage(s);
 				break;
@@ -307,8 +308,7 @@ GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char)
 			d->wascrlf 	= FALSE;
 		}
 		if (d->EditMode) {
-			if (strlen(d->Msg.Buffer+d->LineStart) == 2 &&
-					strncmp(d->Msg. Buffer + d->LineStart, "> ", 2) == 0) {
+			if (strcmp(d->Msg.Buffer + d->LineStart, AT_SMS_PROMPT_PADDED) == 0) {
 				s->Phone.Data.RequestMsg	= &d->Msg;
 				s->Phone.Data.DispatchError	= s->Phone.Functions->DispatchMessage(s);
 			}

--- a/libgammu/protocol/at/at.h
+++ b/libgammu/protocol/at/at.h
@@ -5,6 +5,12 @@
 
 #include "../protocol.h"
 
+/* 3GPP TS 27.005 section 3.5.1 defines the SMS edit prompt as the four
+ * character sequence <CR><LF><greater_than><space>. Some modems (eg. SIMCom
+ * SIM7670G) omit the trailing space and terminate the line instead. */
+#define AT_SMS_PROMPT_PADDED	"> "
+#define AT_SMS_PROMPT_BARE	">"
+
 GSM_Error AT_StateMachine(GSM_StateMachine *s, unsigned char rx_char);
 GSM_Error AT_Initialise(GSM_StateMachine *s);
 


### PR DESCRIPTION
Fixes #1176.

Some modems emit the SMS edit prompt as `\r\n>\r\n` rather than the more common `\r\n> `. Two independent gates compared for the exact string `"> "`, so such a prompt was never recognised and `GSM_SendSMS` blocked in `GSM_WaitFor` until `commtimeout`, returning `ERR_TIMEOUT` on a healthy modem.

Raw bytes from a SIMCom SIM7670G after `AT+CMGS=26`:

```
00000010  41 54 2b 43 4d 47 53 3d  32 36 0d 0d 0a 3e 0d 0a  |AT+CMGS=26...>..|
00000020  0d                                                |.|
```

No `0x20` after `0x3E`.

## Changes

**`libgammu/protocol/at/at.h`** — declares the two prompt forms, citing 3GPP TS 27.005 section 3.5.1, so the literals are not repeated across translation units:

```c
#define AT_SMS_PROMPT_PADDED	"> "
#define AT_SMS_PROMPT_BARE	">"
```

**`libgammu/protocol/at/at.c`** — `AT_StateMachine()` tested for the prompt only in the `default:` branch of the character switch. A bare `>` sets `LineStart` but fails the `strlen(...) == 2` test; the following `\r` then enters `case 10/13:`, so the check is never re-evaluated and the frame is never dispatched. Added a check for a CRLF-terminated single `>` in the line-processing branch.

**`libgammu/phone/at/atgen.c`** — `strcmp(line, "> ")` extended to also accept `">"`, so the dispatched frame is classified as `AT_Reply_SMSEdit`.

Modems that send `"> "` continue to take the existing `default:` path; the new branch requires a line terminator, which those modems do not send at the prompt, so there is no double dispatch.

## Verification

SIMCom SIM7670G-LNGV, firmware `2382B02SIM767XM5A`, USB CDC-ACM, `connection = at115200`, gammu 1.42.0 on aarch64.

Stock:

```
Sending SMS 1/1No response in specified timeout. Probably the phone is not connected.
EXIT=114

Waiting for modem prompt
Escaping SMS mode
GSM_SendSMS failed with error TIMEOUT[14]
```

Patched:

```
Sending SMS 1/1…waiting for network answer..OK, message reference=4
EXIT=0
```

Message delivered. `gammu identify` and normal `OK`/`ERROR` handling are unaffected.

An intermediate build with only the `at.c` change returned `UNKNOWNRESPONSE[16]` immediately instead of hanging, confirming the two gates are independent and both are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
