### PR TITLE
smsd: include errmsg.h for the MySQL client error constants

### DIFF
--- a/smsd/services/mysql.c
+++ b/smsd/services/mysql.c
@@ -21,6 +21,10 @@
 #include "../core.h"
 #include "sql.h"
 
+/* Defines the CR_* client error constants used below. Oracle's mysql.h pulls
+ * this in for us, MariaDB Connector/C does not, so include it explicitly. */
+#include <errmsg.h>
+
 long long SMSDMySQL_GetNumber(GSM_SMSDConfig * Config, SQL_result *res, unsigned int field)
 {
 	return strtoll(res->my.row[field], NULL, 10);


### PR DESCRIPTION
Building the SMSD MySQL service against MariaDB Connector/C fails:

```
smsd/services/mysql.c: In function 'SMSDMySQL_Connect':
smsd/services/mysql.c:113:30: error: 'CR_SERVER_GONE_ERROR' undeclared (first use in this function)
smsd/services/mysql.c:113:63: error: 'CR_CONN_HOST_ERROR' undeclared; did you mean 'ER_BAD_HOST_ERROR'?
smsd/services/mysql.c:113:94: error: 'CR_CONNECTION_ERROR' undeclared; did you mean 'MARIADB_CONNECTION_ERROR'?
smsd/services/mysql.c: In function 'SMSDMySQL_Query':
smsd/services/mysql.c:142:63: error: 'CR_SERVER_LOST' undeclared (first use in this function)
smsd/services/mysql.c:142:90: error: 'CR_SERVER_HANDSHAKE_ERR' undeclared (first use in this function)
```

All five constants are defined in `errmsg.h`. `mysql.c` never includes it — Oracle's `mysql.h`
pulls it in transitively, and MariaDB Connector/C does not, so the file only compiles against
Oracle's client headers.

This adds the include directly, inside the existing `HAVE_MYSQL_MYSQL_H` guard.

## Why it appears now

1.42.0's `mysql.c` does not reference `CR_*` at all. The reconnect handling that uses them was added
afterwards, so releases from 1.43 onward fail to build wherever MariaDB's connector is the MySQL
client — which is the default on Alpine, and common on other distributions.

## Verified

Built gammu 1.44.0 on Alpine (`mariadb-dev`, i.e. MariaDB Connector/C) with the equivalent change
applied as a patch. Without it the build fails as above; with it the build completes and all
subpackages are produced:

```
gammu-1.44.0-r0.apk       gammu-dev-1.44.0-r0.apk    gammu-doc-1.44.0-r0.apk
gammu-lang-1.44.0-r0.apk  gammu-libs-1.44.0-r0.apk   gammu-smsd-1.44.0-r0.apk

$ gammu --version
[Gammu version 1.44.0]
```

Alpine has been stuck on gammu 1.42.0 since 2020; this is one of the two things blocking the
upgrade there (alpine/aports!106638). Once this is released, that distribution patch can be dropped.

I have not tested against Oracle's client headers — the include is unconditional, and `errmsg.h`
exists in both implementations, so it should be a no-op there, but it is worth a second opinion from
someone who builds that configuration.
