### PR TITLE
fix(unicode): grow console conversion buffers dynamically

### DIFF
--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -271,10 +271,39 @@ void DecodeUnicode (const unsigned char *src, char *dest)
 	dest[o]=0;
 }
 
+/*
+ * Grow a conversion buffer so that the decoded form of src always fits.
+ * Every UTF-16 unit expands to at most MB_LEN_MAX bytes (wctomb output,
+ * UTF-8 sequences and the '?' fallback all fit in that bound).
+ * Returns NULL when out of memory, keeping the old buffer valid.
+ */
+static char *EnsureConversionBuffer(char **buffer, size_t *size,
+				    const unsigned char *src)
+{
+	size_t needed = UnicodeLength(src) * MB_LEN_MAX + 1;
+	char *tmp;
+
+	if (*size < needed) {
+		tmp = (char *)realloc(*buffer, needed);
+		if (tmp == NULL)
+			return NULL;
+		*buffer = tmp;
+		*size = needed;
+	}
+	return *buffer;
+}
+
 /* Decode Unicode string and return as function result */
 char *DecodeUnicodeString (const unsigned char *src)
 {
- 	static char dest[500];
+	static char *dest;
+	static size_t dest_size;
+	static char empty[1];
+
+	if (EnsureConversionBuffer(&dest, &dest_size, src) == NULL) {
+		empty[0] = 0;
+		return empty;
+	}
 
 	DecodeUnicode(src,dest);
 	return dest;
@@ -285,7 +314,14 @@ char *DecodeUnicodeString (const unsigned char *src)
  */
 char *DecodeUnicodeConsole(const unsigned char *src)
 {
- 	static char dest[500];
+	static char *dest;
+	static size_t dest_size;
+	static char empty[1];
+
+	if (EnsureConversionBuffer(&dest, &dest_size, src) == NULL) {
+		empty[0] = 0;
+		return empty;
+	}
 
 	if (GSM_global_debug.coding[0] != 0) {
 		if (!strcmp(GSM_global_debug.coding,"utf8")) {

--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -272,15 +272,30 @@ void DecodeUnicode (const unsigned char *src, char *dest)
 }
 
 /*
+ * Every UTF-16 unit expands to at most MB_LEN_MAX bytes via wctomb() (the
+ * '?' fallback is one byte) and to at most 3 bytes via EncodeUTF8() (4-byte
+ * UTF-8 sequences encode surrogate pairs, i.e. two UTF-16 units).  MB_LEN_MAX
+ * only bounds the locale's multibyte encoding, so keep a separate floor for
+ * the explicit UTF-8 path.
+ */
+#define CONVERSION_UNIT_MAX (MB_LEN_MAX > 3 ? MB_LEN_MAX : 3)
+
+/*
+ * Callers nest conversions in a single expression, for example
+ * strcmp(DecodeUnicodeString(a), DecodeUnicodeString(b)), so results are
+ * returned from a set of rotating buffers: each call uses the next slot and
+ * never reallocates the storage handed out by the previous calls.
+ */
+#define CONVERSION_BUFFERS 4
+
+/*
  * Grow a conversion buffer so that the decoded form of src always fits.
- * Every UTF-16 unit expands to at most MB_LEN_MAX bytes (wctomb output,
- * UTF-8 sequences and the '?' fallback all fit in that bound).
  * Returns NULL when out of memory, keeping the old buffer valid.
  */
 static char *EnsureConversionBuffer(char **buffer, size_t *size,
 				    const unsigned char *src)
 {
-	size_t needed = UnicodeLength(src) * MB_LEN_MAX + 1;
+	size_t needed = UnicodeLength(src) * CONVERSION_UNIT_MAX + 1;
 	char *tmp;
 
 	if (*size < needed) {
@@ -296,17 +311,21 @@ static char *EnsureConversionBuffer(char **buffer, size_t *size,
 /* Decode Unicode string and return as function result */
 char *DecodeUnicodeString (const unsigned char *src)
 {
-	static char *dest;
-	static size_t dest_size;
+	static char *dest[CONVERSION_BUFFERS];
+	static size_t dest_size[CONVERSION_BUFFERS];
+	static unsigned int slot;
 	static char empty[1];
+	char *buffer;
 
-	if (EnsureConversionBuffer(&dest, &dest_size, src) == NULL) {
+	slot = (slot + 1) % CONVERSION_BUFFERS;
+	buffer = EnsureConversionBuffer(&dest[slot], &dest_size[slot], src);
+	if (buffer == NULL) {
 		empty[0] = 0;
 		return empty;
 	}
 
-	DecodeUnicode(src,dest);
-	return dest;
+	DecodeUnicode(src,buffer);
+	return buffer;
 }
 
 /* Decode Unicode string to UTF8 or other console charset
@@ -314,34 +333,38 @@ char *DecodeUnicodeString (const unsigned char *src)
  */
 char *DecodeUnicodeConsole(const unsigned char *src)
 {
-	static char *dest;
-	static size_t dest_size;
+	static char *dest[CONVERSION_BUFFERS];
+	static size_t dest_size[CONVERSION_BUFFERS];
+	static unsigned int slot;
 	static char empty[1];
+	char *buffer;
 
-	if (EnsureConversionBuffer(&dest, &dest_size, src) == NULL) {
+	slot = (slot + 1) % CONVERSION_BUFFERS;
+	buffer = EnsureConversionBuffer(&dest[slot], &dest_size[slot], src);
+	if (buffer == NULL) {
 		empty[0] = 0;
 		return empty;
 	}
 
 	if (GSM_global_debug.coding[0] != 0) {
 		if (!strcmp(GSM_global_debug.coding,"utf8")) {
-			EncodeUTF8(dest, src);
+			EncodeUTF8(buffer, src);
 		} else {
 #ifdef WIN32
 			setlocale(LC_ALL, GSM_global_debug.coding);
 #endif
-			DecodeUnicode(src,dest);
+			DecodeUnicode(src,buffer);
 		}
 	} else {
 #ifdef WIN32
 		setlocale(LC_ALL, ".OCP");
 #endif
-		DecodeUnicode(src,dest);
+		DecodeUnicode(src,buffer);
 #ifdef WIN32
 		setlocale(LC_ALL, ".ACP");
 #endif
 	}
-	return dest;
+	return buffer;
 }
 
 /* Encode string to Unicode. Len is number of input chars */

--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -29,6 +29,7 @@
 #include <ctype.h>
 #include <locale.h>
 #include <limits.h>
+#include <stdint.h>
 #ifdef WIN32
 #  define WIN32_LEAN_AND_MEAN
 #  include <windows.h>
@@ -290,13 +291,19 @@ void DecodeUnicode (const unsigned char *src, char *dest)
 
 /*
  * Grow a conversion buffer so that the decoded form of src always fits.
- * Returns NULL when out of memory, keeping the old buffer valid.
+ * Returns NULL when out of memory or when the input is so long that the
+ * allocation size would overflow, keeping the old buffer valid.
  */
 static char *EnsureConversionBuffer(char **buffer, size_t *size,
 				    const unsigned char *src)
 {
-	size_t needed = UnicodeLength(src) * CONVERSION_UNIT_MAX + 1;
+	size_t len = UnicodeLength(src);
+	size_t needed;
 	char *tmp;
+
+	if (len > (SIZE_MAX - 1) / CONVERSION_UNIT_MAX)
+		return NULL;
+	needed = len * CONVERSION_UNIT_MAX + 1;
 
 	if (*size < needed) {
 		tmp = (char *)realloc(*buffer, needed);


### PR DESCRIPTION
DecodeUnicodeString() and DecodeUnicodeConsole() returned the converted string through fixed static 500 byte buffers. Since commit "fix(unicode): prevent truncation on invalid locale input", invalid bytes become U+FFFD instead of terminating the conversion, so decoding a multipart 8-bit message whose payload is not text (for example the EMS animation built by the sms-cmdline-ANIMATION test) produces the full-length converted string and overflows the 500 byte buffer, corrupting adjacent globals.

This made sms-cmdline-ANIMATION crash with SIGSEGV on the Debian armhf, powerpc, x32 and hurd-i386 buildds; on other architectures the overflow corrupts memory silently. AddressSanitizer reports the overflow on amd64 as well. Long valid text (a multipart SMS can decode to well over 500 bytes) could already overflow these buffers before.

Size the buffers dynamically from the UTF-16 length of the input instead: every UTF-16 unit expands to at most MB_LEN_MAX bytes via wctomb() or EncodeUTF8().