### PR TITLE
fix(sms): do not over-read packed 7bit user data

### DIFF
--- a/libgammu/misc/coding/coding.c
+++ b/libgammu/misc/coding/coding.c
@@ -1032,6 +1032,9 @@ int GSM_UnpackEightBitsToSeven(size_t offset, size_t in_length, size_t out_lengt
 
         while ((size_t)(input_pos - input) < in_length) {
 
+                /* Never consume input the output has no room for */
+                if ((size_t)(output_pos - output) >= out_length) break;
+
                 *output_pos = ((*input_pos & ByteMask) << (7 - Bits)) | Rest;
                 Rest = *input_pos >> Bits;
 

--- a/libgammu/service/sms/gsmsms.c
+++ b/libgammu/service/sms/gsmsms.c
@@ -360,7 +360,9 @@ GSM_Error GSM_DecodeSMSFrameText(GSM_Debug_Info *di, GSM_SMSMessage *SMS, unsign
 				SMS->Length = 0;
 				break;
 			}
-			GSM_UnpackEightBitsToSeven(w, buffer[Layout.TPUDL]-off, SMS->Length, buffer+(Layout.Text+off), output);
+			/* TPUDL counts septets here, so the packed text occupies
+			   ceil(7 * TPUDL / 8) octets minus the UDH */
+			GSM_UnpackEightBitsToSeven(w, (buffer[Layout.TPUDL]*7+7)/8-off, SMS->Length, buffer+(Layout.Text+off), output);
 			smfprintf(di, "7 bit SMS, length %i\n",SMS->Length);
 			DecodeDefault (SMS->Text, output, SMS->Length, TRUE, NULL);
 			smfprintf(di, "%s\n",DecodeUnicodeString(SMS->Text));
@@ -809,7 +811,9 @@ GSM_Error GSM_DecodePDUFrame(GSM_Debug_Info *di, GSM_SMSMessage *SMS, const unsi
 					SMS->Length = 0;
 					break;
 				}
-				GSM_UnpackEightBitsToSeven(w, udl-SMS->UDH.Length, SMS->Length, buffer+(pos + 1+SMS->UDH.Length), output);
+				/* udl counts septets here, so the packed text occupies
+				   ceil(7 * udl / 8) octets minus the UDH */
+				GSM_UnpackEightBitsToSeven(w, (udl*7+7)/8-SMS->UDH.Length, SMS->Length, buffer+(pos + 1+SMS->UDH.Length), output);
 				smfprintf(di, "7 bit SMS, length %i\n",SMS->Length);
 				DecodeDefault (SMS->Text, output, SMS->Length, TRUE, NULL);
 				smfprintf(di, "%s\n",DecodeUnicodeString(SMS->Text));


### PR DESCRIPTION
TPUDL counts septets for the default alphabet, but the decoders passed it (minus the UDH octets) as the octet input length to GSM_UnpackEightBitsToSeven(), overstating the packed size by up to TPUDL/8 bytes and reading past the end of the frame on perfectly valid messages (caught by ASan in sms-nokia-01/02).

Pass the real packed size, ceil(7 * TPUDL / 8) octets minus the UDH, instead, and make the unpacker stop consuming input once the requested output length has been produced.